### PR TITLE
docs: improve READMEs for orchestrator and its components

### DIFF
--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -17,6 +17,13 @@ The orchestrator is composed of a central **agent** and multiple **frontends** f
 
 This is the recommended setup for local development. You will need to open two separate terminal windows.
 
+### Prerequisite: Environment Configuration
+
+Before launching the services, you must create environment files for both the agent and the frontend. These files contain sensitive information and are not stored in the repository.
+
+*   **For the Agent:** Create a `.env` file in the `orchestrator/agent` directory. See the [Agent README](./agent/README.MD) for detailed instructions.
+*   **For the Frontend:** Create a `.env.local` file in the `orchestrator/frontend_v2` directory. See the [Frontend v2 README](./frontend_v2/README.md) for detailed instructions.
+
 ### Terminal 1: Run the Agent
 
 1.  **Navigate to the agent directory:**
@@ -24,20 +31,10 @@ This is the recommended setup for local development. You will need to open two s
     cd orchestrator/agent
     ```
 
-2.  **Set up the Python environment and install dependencies** (if you haven't already):
-    ```bash
-    python -m venv .venv
-    source .venv/bin/activate
-    pip install -r requirements.txt
-    ```
+2.  **Set up and configure the agent:**
+    Follow the setup steps in the [Agent README](./agent/README.MD), which include creating a virtual environment, installing dependencies, and creating your `.env` and `remote_agents_config.yaml` files.
 
-3.  **Configure the remote agents:**
-    ```bash
-    cp broadcast_orchestrator/remote_agents_config.yaml.example broadcast_orchestrator/remote_agents_config.yaml
-    ```
-    *Update `remote_agents_config.yaml` with the correct endpoints for your downstream agents.*
-
-4.  **Start the agent server:**
+3.  **Start the agent server:**
     ```bash
     uvicorn main:app --host 0.0.0.0 --port 8080 --reload
     ```
@@ -50,10 +47,8 @@ This is the recommended setup for local development. You will need to open two s
     cd orchestrator/frontend_v2
     ```
 
-2.  **Install dependencies** (if you haven't already):
-    ```bash
-    npm install
-    ```
+2.  **Set up and configure the frontend:**
+    Follow the setup steps in the [Frontend v2 README](./frontend_v2/README.md), which include installing dependencies and creating your `.env.local` file.
 
 3.  **Start the development server:**
     ```bash

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -1,35 +1,92 @@
-# Orchestrator Directory
+# Broadcast Orchestrator
 
-In this directory is the code for the Orchestrator Agent
+Welcome to the Broadcast Orchestrator directory. This project is a multi-agent system designed to streamline broadcast operations by orchestrating various specialized agents.
 
-## Create & Activate Virtual Environment (Recommended):
+This README provides a central guide for setting up and running the different components of the system locally.
 
-```bash
-python -m venv .venv
-```
-### macOS/Linux:
+## Project Structure
 
-```bash
-source .venv/bin/activate
-```
-### Windows CMD:
-```bash
-.venv\Scripts\activate.bat
-```
+The orchestrator is composed of a central **agent** and multiple **frontends** for interaction:
 
-### Windows PowerShell:
-```bash
-.venv\Scripts\Activate.ps1
-```
+*   **`agent/`**: The core of the system. This is a Python-based routing agent that receives user requests, interprets their intent, and delegates tasks to the appropriate downstream agents (e.g., Cuez, EVS, TX). For more details, see the [Agent README](./agent/README.MD).
+*   **`frontend_v2/`**: The recommended web interface for interacting with the orchestrator. It is a modern React application that provides a rich user experience. For more details, see the [Frontend v2 README](./frontend_v2/README.md).
+*   **`frontend/`**: A legacy web interface. This is the original UI and is kept for reference. For new development, please use `frontend_v2`. For more details, see the [Legacy Frontend README](./frontend/README.md).
+*   **`app.py`**: A simple, all-in-one Gradio application that runs both the agent and a basic UI in a single process. This is useful for quick tests and demonstrations.
 
-## Install packages
+## Quick Start: Running the Agent and v2 Frontend
 
-```bash
-pip install -r requirements.txt
-```
+This is the recommended setup for local development. You will need to open two separate terminal windows.
 
-## Run Orchistrator Agent and UI
+### Terminal 1: Run the Agent
 
-```bash
-python app.py
-```
+1.  **Navigate to the agent directory:**
+    ```bash
+    cd orchestrator/agent
+    ```
+
+2.  **Set up the Python environment and install dependencies** (if you haven't already):
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements.txt
+    ```
+
+3.  **Configure the remote agents:**
+    ```bash
+    cp broadcast_orchestrator/remote_agents_config.yaml.example broadcast_orchestrator/remote_agents_config.yaml
+    ```
+    *Update `remote_agents_config.yaml` with the correct endpoints for your downstream agents.*
+
+4.  **Start the agent server:**
+    ```bash
+    uvicorn main:app --host 0.0.0.0 --port 8080 --reload
+    ```
+    *The agent API will now be running at `http://localhost:8080`.*
+
+### Terminal 2: Run the Frontend (v2)
+
+1.  **Navigate to the v2 frontend directory:**
+    ```bash
+    cd orchestrator/frontend_v2
+    ```
+
+2.  **Install dependencies** (if you haven't already):
+    ```bash
+    npm install
+    ```
+
+3.  **Start the development server:**
+    ```bash
+    npm run dev
+    ```
+    *The frontend will now be running at `http://localhost:5173` (or another port if 5173 is busy).*
+
+You can now open your browser to the frontend address and start using the orchestrator.
+
+## Alternative Setups
+
+### Running with the Legacy Frontend
+
+If you need to use the legacy UI, follow the "Quick Start" instructions but in Terminal 2, navigate to `orchestrator/frontend` and run `npm run dev`. The legacy frontend will be available at `http://localhost:3000`.
+
+### Running the Simple Gradio UI
+
+For a quick, all-in-one setup, you can use the `app.py` script. This runs the agent and a simple UI in one process.
+
+1.  **Navigate to the orchestrator directory:**
+    ```bash
+    cd orchestrator
+    ```
+
+2.  **Set up the Python environment and install dependencies** (this uses the same `requirements.txt` as the agent):
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate
+    pip install -r agent/requirements.txt
+    ```
+
+3.  **Run the application:**
+    ```bash
+    python app.py
+    ```
+    *The Gradio UI will be available at `http://localhost:8083`.*

--- a/orchestrator/agent/README.MD
+++ b/orchestrator/agent/README.MD
@@ -1,15 +1,65 @@
-# Broadcaster Orchestrator Source code
+# Broadcast Orchestrator Agent
 
-## Setup Locally
+This directory contains the source code for the Broadcast Orchestrator Agent.
 
-Recommend setting up a python Virtual environment.
+The agent is the core backend of the orchestrator system. It is a routing agent responsible for receiving user requests, interpreting them, and delegating tasks to the appropriate specialized agents (e.g., Cuez, EVS, TX). It exposes a REST API that the frontends can interact with.
 
-`pip install -r requirements.txt`
+## Setup and Running Locally
 
-Then for running locally run
+### 1. Create a Virtual Environment (Recommended)
 
-`uvicorn main:app --reload`
+It is recommended to use a Python virtual environment to manage dependencies.
 
-## Contributing
+```bash
+python -m venv .venv
+```
 
-Note this python code follows the Google linting and 2 space indentation not 4.
+**Activate the environment:**
+
+*   **macOS/Linux:**
+    ```bash
+    source .venv/bin/activate
+    ```
+*   **Windows (CMD):**
+    ```bash
+    .venv\Scripts\activate.bat
+    ```
+*   **Windows (PowerShell):**
+    ```bash
+    .venv\Scripts\Activate.ps1
+    ```
+
+### 2. Install Dependencies
+
+Install the required Python packages using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Configure Remote Agents
+
+The agent needs to know the endpoints of the specialized agents it orchestrates. This is configured in the `broadcast_orchestrator/remote_agents_config.yaml` file. Before running the agent, create a copy of the example config and update it with the correct URLs for your remote agent instances.
+
+```bash
+# Make sure you are in the orchestrator/agent directory
+cp broadcast_orchestrator/remote_agents_config.yaml.example broadcast_orchestrator/remote_agents_config.yaml
+```
+
+### 4. Run the Agent Server
+
+The agent is served using `uvicorn`. To run it in development mode with auto-reloading:
+
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8080 --reload
+```
+
+The API will be available at `http://localhost:8080`. You can view the auto-generated documentation at `http://localhost:8080/docs`.
+
+## Code Style
+
+This Python code follows the Google Python Style Guide, which includes:
+*   Using 2 spaces for indentation (not 4).
+*   Adhering to Google's linting rules.
+
+Please ensure your contributions match this style.

--- a/orchestrator/agent/README.MD
+++ b/orchestrator/agent/README.MD
@@ -37,7 +37,21 @@ Install the required Python packages using pip:
 pip install -r requirements.txt
 ```
 
-### 3. Configure Remote Agents
+### 3. Create Environment Configuration
+
+The agent requires a `.env` file for sensitive configuration, such as API keys and service endpoints.
+
+1.  **Create the `.env` file:**
+    ```bash
+    cp .env-example .env
+    ```
+
+2.  **Populate the `.env` file:**
+    You must populate the `.env` file with the correct values for your environment. These secrets (like `GOOGLE_API_KEY`) are not stored in the repository and should be obtained from a secure source, such as Google Cloud Storage or your project's secret manager.
+
+    For local development, you may also need to set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to your Firebase service account key file.
+
+### 4. Configure Remote Agents
 
 The agent needs to know the endpoints of the specialized agents it orchestrates. This is configured in the `broadcast_orchestrator/remote_agents_config.yaml` file. Before running the agent, create a copy of the example config and update it with the correct URLs for your remote agent instances.
 
@@ -46,7 +60,7 @@ The agent needs to know the endpoints of the specialized agents it orchestrates.
 cp broadcast_orchestrator/remote_agents_config.yaml.example broadcast_orchestrator/remote_agents_config.yaml
 ```
 
-### 4. Run the Agent Server
+### 5. Run the Agent Server
 
 The agent is served using `uvicorn`. To run it in development mode with auto-reloading:
 

--- a/orchestrator/frontend/README.md
+++ b/orchestrator/frontend/README.md
@@ -1,6 +1,28 @@
-# Orchestrator Fromntend UI
+# Orchestrator Frontend (Legacy v1)
 
-## Dev
+This directory contains the legacy v1 frontend for the Broadcast Orchestrator.
 
-1. Run `npm install`
-2. Run `npm run dev`
+> **Note:** This is the older frontend. For new development and the latest features, please use the **[v2 Frontend](../frontend_v2)**.
+
+This UI provides a basic interface for interacting with the Broadcast Orchestrator agent. It allows users to send commands and view responses from the agent.
+
+## Development Setup
+
+### 1. Install Dependencies
+
+Navigate to this directory and install the required npm packages:
+
+```bash
+# From the orchestrator/frontend directory
+npm install
+```
+
+### 2. Run the Development Server
+
+To start the local development server:
+
+```bash
+npm run dev
+```
+
+The application will typically be available at `http://localhost:3000`. The frontend is configured to connect to the agent's API, which is expected to be running at `http://localhost:8080`.

--- a/orchestrator/frontend_v2/README.md
+++ b/orchestrator/frontend_v2/README.md
@@ -15,11 +15,36 @@ Navigate to this directory and install the required npm packages:
 npm install
 ```
 
-### 2. Configure the Backend API
+### 2. Create Environment Configuration
 
-The frontend needs to know the URL of the agent's API. By default, it will try to connect to `http://localhost:8080`. This can be configured via environment variables if your agent is running elsewhere.
+The frontend requires a `.env.local` file for configuration, including Firebase credentials.
 
-### 3. Run the Development Server
+1.  **Create the file:**
+    ```bash
+    touch .env.local
+    ```
+
+2.  **Populate the file:**
+    Add the following environment variables to the file. The values for your Firebase project can be found in the Firebase console. These secrets should be sourced securely and not be committed to the repository.
+
+    ```
+    VITE_FIREBASE_API_KEY="YOUR_API_KEY"
+    VITE_FIREBASE_AUTH_DOMAIN="YOUR_AUTH_DOMAIN"
+    VITE_FIREBASE_PROJECT_ID="YOUR_PROJECT_ID"
+    VITE_FIREBASE_STORAGE_BUCKET="YOUR_STORAGE_BUCKET"
+    VITE_FIREBASE_MESSAGING_SENDER_ID="YOUR_MESSAGING_SENDER_ID"
+    VITE_FIREBASE_APP_ID="YOUR_APP_ID"
+    ```
+
+### 3. Configure the Backend API
+
+The frontend needs to know the URL of the agent's API. By default, it will try to connect to `http://localhost:8080`. This can be configured via an environment variable if your agent is running elsewhere. You can add this to your `.env.local` file:
+
+```
+VITE_AGENT_API_URL="http://localhost:8080"
+```
+
+### 4. Run the Development Server
 
 To start the local development server:
 

--- a/orchestrator/frontend_v2/README.md
+++ b/orchestrator/frontend_v2/README.md
@@ -1,20 +1,40 @@
-# Base44 App
+# Orchestrator Frontend (v2)
 
+This directory contains the v2 frontend for the Broadcast Orchestrator. This is the recommended UI for interacting with the system.
 
-This app was created automatically by Base44.
-It's a Vite+React app that communicates with the Base44 API.
+This application is a modern web interface built with React and Vite. It provides a rich user experience for sending requests to the orchestrator agent and visualizing the responses and logs.
 
-## Running the app
+## Development Setup
+
+### 1. Install Dependencies
+
+Navigate to this directory and install the required npm packages:
 
 ```bash
+# From the orchestrator/frontend_v2 directory
 npm install
+```
+
+### 2. Configure the Backend API
+
+The frontend needs to know the URL of the agent's API. By default, it will try to connect to `http://localhost:8080`. This can be configured via environment variables if your agent is running elsewhere.
+
+### 3. Run the Development Server
+
+To start the local development server:
+
+```bash
 npm run dev
 ```
 
-## Building the app
+The application will be available at `http://localhost:5173` by default (check the console output for the exact URL).
+
+## Building for Production
+
+To create a production-ready build of the application:
 
 ```bash
 npm run build
 ```
 
-For more information and support, please contact Base44 support at app@base44.com.
+The optimized static assets will be placed in the `dist` directory.


### PR DESCRIPTION
This commit completely overhauls the documentation for the `orchestrator` directory and its sub-components (`agent`, `frontend`, `frontend_v2`).

The main `orchestrator/README.md` now serves as a central, unifying guide for new developers. It explains the project's structure and provides clear, step-by-step instructions for setting up and running the recommended local development environment (agent + v2 frontend). It also details alternative setups, such as using the legacy frontend or the simple Gradio UI.

The READMEs for the individual components have been significantly improved:
- `agent/README.MD`: Now includes a detailed description of the agent's role, clearer setup instructions, and an explanation of the `remote_agents_config.yaml` file.
- `frontend/README.md`: Is now clearly marked as a legacy component, with a recommendation to use `frontend_v2`.
- `frontend_v2/README.md`: The generic boilerplate has been replaced with project-specific information, including setup instructions and how it connects to the backend.