### PR TITLE
Route agent-health-checker egress via VPC

### DIFF
--- a/infrastructure/cloud_build_runner_iam.tf
+++ b/infrastructure/cloud_build_runner_iam.tf
@@ -1,0 +1,21 @@
+resource "google_project_iam_member" "cloud_build_runner_logging_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:cloud-build-runner@${var.project_id}.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "cloud_build_runner_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:cloud-build-runner@${var.project_id}.iam.gserviceaccount.com"
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+resource "google_service_account_iam_member" "cloud_build_runner_compute_sa_user" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:cloud-build-runner@${var.project_id}.iam.gserviceaccount.com"
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -17,6 +17,7 @@ module "agent_health_checker" {
 
   project_id                          = var.project_id
   region                              = var.region
+  vpc_access_connector_id             = module.orchestrator.vpc_access_connector_id
 }
 
 module "activity_agent" {

--- a/infrastructure/modules/agent-health-checker/main.tf
+++ b/infrastructure/modules/agent-health-checker/main.tf
@@ -37,6 +37,13 @@ resource "google_cloud_run_v2_job" "agent_health_checker" {
   template {
     template {
       service_account = google_service_account.agent_health_checker.email
+      dynamic "vpc_access" {
+        for_each = var.vpc_access_connector_id != null ? [1] : []
+        content {
+          connector = var.vpc_access_connector_id
+          egress    = "ALL_TRAFFIC"
+        }
+      }
       containers {
         image = format("%s-docker.pkg.dev/%s/cloud-run-source-deploy/agent-health-check:%s", var.region, var.project_id, var.image_tag)
         env {
@@ -45,6 +52,12 @@ resource "google_cloud_run_v2_job" "agent_health_checker" {
         }
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].template[0].containers[0].image,
+    ]
   }
 }
 

--- a/infrastructure/modules/agent-health-checker/variables.tf
+++ b/infrastructure/modules/agent-health-checker/variables.tf
@@ -13,3 +13,9 @@ variable "image_tag" {
   type        = string
   default     = "latest"
 }
+
+variable "vpc_access_connector_id" {
+  description = "The ID of the VPC Access Connector to use for the Cloud Run Job."
+  type        = string
+  default     = null
+}

--- a/infrastructure/modules/orchestrator/main.tf
+++ b/infrastructure/modules/orchestrator/main.tf
@@ -124,6 +124,12 @@ resource "google_cloud_run_v2_service" "orchestrator_agent" {
     percent  = 100
   }
 
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+    ]
+  }
+
   depends_on = [google_vpc_access_connector.connector]
 }
 

--- a/infrastructure/modules/orchestrator/outputs.tf
+++ b/infrastructure/modules/orchestrator/outputs.tf
@@ -12,3 +12,8 @@ output "nat_ip_address" {
   description = "The static outbound IP address of the Cloud Run service."
   value       = google_compute_address.nat_ip.address
 }
+
+output "vpc_access_connector_id" {
+  description = "The ID of the VPC Access Connector."
+  value       = google_vpc_access_connector.connector.id
+}


### PR DESCRIPTION
Also

* Ignore container versions for orchestrator and agent health checker
* Add mamanagement of IAM for Cloud BUild runner under terraform