### PR TITLE
feat(agent-health-checker): Save full agent card to Firestore

### DIFF
--- a/orchestrator/agent-health-checker/main.py
+++ b/orchestrator/agent-health-checker/main.py
@@ -107,12 +107,14 @@ async def check_agent_health(agent_id, agent_dict):
                                          skills=[],
                                          version="1.0")
                     a2a_client = A2AClient(client, a2a_card)
-                    message_request = SendMessageRequest(
-                        id=str(uuid.uuid4()),
-                        params=MessageSendParams(message=Message(
-                            messageId=str(uuid.uuid4()),
-                            role="user",
-                            parts=[Part(root=TextPart(text="Are you there?"))])))
+                    health_check_message = Message(
+                        messageId=str(uuid.uuid4()),
+                        role="user",
+                        parts=[Part(root=TextPart(text="Are you there?"))])
+                    message_params = MessageSendParams(
+                        message=health_check_message)
+                    message_request = SendMessageRequest(id=str(uuid.uuid4()),
+                                                         params=message_params)
                     response = await a2a_client.send_message(message_request)
 
                     if response:


### PR DESCRIPTION
The agent-health-checker job now fetches and saves the entire agent card to the `agent_status` collection in Firestore. This provides more detailed information for debugging purposes.

The following changes were made:
- The `get_agent_tags` function was refactored to `get_agent_card` to better reflect its new purpose of fetching the entire agent card.
- The `check_agent_health` function was updated to use the new `get_agent_card` function and return the full card.
- The main loop was updated to save the fetched card to Firestore, replacing the previous `tags` field.
- The unit tests in `test_main.py` were updated to align with these changes, ensuring the new functionality is correctly tested.
- Linting issues were fixed to comply with the project's coding standards.