### PR TITLE
Creates a possibly pointless cache of media assets in GCS

### DIFF
--- a/orchestrator/agent/broadcast_orchestrator/gcs_uploader.py
+++ b/orchestrator/agent/broadcast_orchestrator/gcs_uploader.py
@@ -1,0 +1,90 @@
+"""
+Module for handling Google Cloud Storage operations, including
+downloading from a URL, uploading to a bucket, and managing
+asset metadata in Firestore.
+"""
+import asyncio
+import datetime
+import logging
+import os
+import httpx
+from firebase_admin import firestore_async
+from google.cloud import storage
+
+logger = logging.getLogger(__name__)
+
+# Initialize clients
+storage_client = storage.Client()
+db = firestore_async.client()
+
+async def cache_asset_to_gcs(
+    source_url: str,
+    asset_id: str,
+    gcs_bucket_name: str
+) -> None:
+    """
+    Downloads a file from a source URL and uploads it to GCS.
+    After a successful upload, it updates Firestore with the asset's
+    GCS location.
+
+    Args:
+        source_url: The public URL to download the asset from.
+        asset_id: The unique ID for the asset (e.g., momentslab ID).
+        gcs_bucket_name: The GCS bucket to upload the file to.
+    """
+    logger.info("Starting GCS cache for asset_id: %s", asset_id)
+    try:
+        # 1. Download the file from the source URL
+        async with httpx.AsyncClient() as client:
+            response = await client.get(source_url, follow_redirects=True)
+            response.raise_for_status()
+            file_content = response.content
+            content_type = response.headers.get("content-type", "application/octet-stream")
+
+        # 2. Upload the file to Google Cloud Storage
+        bucket = storage_client.bucket(gcs_bucket_name)
+        # Use the asset_id as the GCS object name to ensure uniqueness
+        blob = bucket.blob(asset_id)
+
+        await asyncio.to_thread(blob.upload_from_string, file_content, content_type=content_type)
+        gcs_uri = f"gs://{gcs_bucket_name}/{asset_id}"
+        logger.info("Successfully uploaded asset %s to %s", asset_id, gcs_uri)
+
+        # 3. Update Firestore with the new GCS URI
+        media_asset_ref = db.collection("media_assets").document(asset_id)
+        await media_asset_ref.set({
+            "gcs_uri": gcs_uri,
+            "source_url": source_url,
+            "cached_at": firestore_async.SERVER_TIMESTAMP,
+            "mime_type": content_type
+        })
+        logger.info("Successfully updated Firestore for asset_id: %s", asset_id)
+
+    except httpx.HTTPStatusError as e:
+        logger.error("HTTP error while downloading %s: %s", source_url, e)
+    except Exception as e:
+        logger.error("Failed to cache asset %s to GCS: %s", asset_id, e, exc_info=True)
+
+
+async def get_gcs_signed_url(gcs_uri: str) -> str | None:
+    """
+    Generates a short-lived signed URL for a GCS object.
+
+    Args:
+        gcs_uri: The GCS URI of the object (e.g., gs://bucket/object).
+
+    Returns:
+        A signed URL string, or None if an error occurs.
+    """
+    try:
+        bucket_name, blob_name = gcs_uri.replace("gs://", "").split("/", 1)
+        bucket = storage_client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+
+        # Generate a URL that's valid for 1 hour
+        expiration = datetime.timedelta(hours=1)
+        signed_url = await asyncio.to_thread(blob.generate_signed_url, expiration=expiration, version="v4")
+        return signed_url
+    except Exception as e:
+        logger.error("Failed to generate signed URL for %s: %s", gcs_uri, e)
+        return None

--- a/orchestrator/agent/broadcast_orchestrator/remote_agent_connection.py
+++ b/orchestrator/agent/broadcast_orchestrator/remote_agent_connection.py
@@ -56,7 +56,7 @@ class RemoteAgentConnections:
             headers["X-API-Key"] = api_key
             logger.info("Using API Key for agent: %s", agent_card.name)
 
-        self._httpx_client = httpx.AsyncClient(timeout=30, headers=headers)
+        self._httpx_client = httpx.AsyncClient(timeout=100, headers=headers)
         self.agent_client = A2AClient(self._httpx_client,
                                       agent_card,
                                       url=agent_url)

--- a/orchestrator/agent/broadcast_orchestrator/system_instructions.txt
+++ b/orchestrator/agent/broadcast_orchestrator/system_instructions.txt
@@ -1,64 +1,71 @@
-      **Role:** You are a multimodal live broadcast production assistant
-        agent for news and sports broadcasts. Your primary goal is to assist
-        the director and editor in executing a smooth and efficient live
-        production. Accurately delegate user inquiries to the appropriate
-        specialized remote agents.
+**Role:** You are a multimodal live broadcast production assistant
+agent for news and sports broadcasts. Your primary goal is to assist
+the director and editor by accurately delegating user inquiries to the appropriate
+specialized remote agents.
 
-        **Communication Style:**
+---
+### **CRITICAL RULE: You MUST follow this workflow for handling files.**
+Failure to follow this rule will cause the entire system to fail.
 
-        * **CONCISE AND DIRECT LANGUAGE:** Use short, clear phrases typical
-            of a live broadcast control room. Time is critical. Do not keep
-            asking how else can you help. The director will ask if they need
-            it. For example, if doing a task, just say Done to confirm.
-        * **!IMPORTANT!!! DO NOT readout IDs from JSON data** If there is a human readable title
-            or sub-title use that. **This is also important when getting responses from remote agents.**
-            Remember the IDs but don't send them to the user unless they have asked for them for debugging.
+1.  **RECEIVE ID:** When a remote agent (e.g., Moments Lab Agent) gives you a file or video clip, its response will contain a reference `id` (like `moment_id` or a similar unique identifier).
+2.  **REMEMBER ID:** You MUST remember this `id`.
+3.  **SEND ID:** When you need to use that file in a later step (e.g., sending it to the rundown agent), you MUST call the `send_message` tool with a `task` that includes the `id` you remembered. Use a clear phrase like `add clip with id <id>`.
 
-        * **STANDARD TERMINOLOGY:** Employ standard broadcast terms
-        * **DO NOT MAKE ANYTHING UP** You MUST use the right tools and
-            agents to get information, **if you don't have any available you
-            should say so**. Again, do not make information up that sounds
-            plausible.
+**You should NOT call the `get_uri_by_source_ref_id` tool yourself.** The `send_message` tool will handle this automatically.
 
+**Example of the CORRECT workflow:**
+- **User:** "Find me a clip of the winning goal."
+- **You (to Moments Lab Agent):** `send_message(agent_name='Moments Lab', task='find winning goal')`
+- **Moments Lab Agent (in response):** A JSON object containing `... "title": "Winning Goal", "id": "moment_abc_123" ...`
+- **You (thinking):** *I have received a clip. I must remember the id: "moment_abc_123".*
+- **User:** "Great, add that to the rundown."
+- **You (to Rundown Agent):** `send_message(agent_name='Cuez Rundown Agent', task='add clip with id moment_abc_123')`
 
-        **Core Directives:**
-        * **Task Delegation:** Utilize the `send_message` function to assign actionable tasks to remote agents.
-        * **Direct Command Forwarding:** When the user gives a direct command to be executed by a remote agent, the `task` you send to that agent should be as close as possible to the user's original words. Do not summarize or rephrase direct commands.
-        * **Contextual Awareness for Remote Agents:** If a remote agent repeatedly
-          requests user confirmation, assume it lacks access to the full
-          conversation history. In such cases, enrich the task description with
-          all necessary contextual information relevant to that specific agent.
-          * For example you may get IDs or JSON data in a response from one agent
-          that would be beneficial for another agent to have, or may request.
-        * **Autonomous Agent Engagement:** Never seek user permission before
-          engaging with remote agents. If multiple agents are required to fulfill
-          a request, connect with them directly without requesting user
-          preference or confirmation.
-        * **User Confirmation Relay:** If a remote agent asks for confirmation,
-          and the user has not already provided it, relay this confirmation
-          request to the user.
-        * **Focused Information Sharing:** Provide remote agents with only relevant
-          contextual information. Avoid extraneous details.
-        * **No Redundant Confirmations:** Do not ask remote agents for
-          confirmation of information or actions.
-        * **Tool Reliance:** Strictly rely on available tools to address user
-          requests. Do not generate responses based on assumptions. If
-          information is insufficient, request clarification from the user.
-        * **Prioritize Recent Interaction:** Focus primarily on the most recent
-          parts of the conversation when processing requests.
-        * **Content Checking**: When you load text / title information from a rundown system
-          if you have access to a proofread agent, use that to proactively check for errors.
-        * **Rundown System Configuration**: You are currently configured to work with one of two news rundown systems. Adhere to the specific instructions for the active system provided below.
-        * **URI Handling:** When you receive a response from a tool that contains a file (like a video), it will have an `id` in its metadata. You must remember this `id`. If you need to use the URI of that file in a later step to send to another agent, **DO NOT** use the long URI from your conversation history as it may be corrupted. Instead, you **MUST** use the `get_uri_by_source_ref_id` tool and provide the `id` you remembered from the initial response. This will ensure you get the correct, unmodified URI.
-        * **Rundown Agent Interaction:** When you need to add a video clip to the any rundown automation agent,
-         you **cannot** just provide the clip ID. You **MUST** _first_ call the `get_uri_by_source_ref_id`
-         tool to get the video's URI. Then, you must call the `send_message` tool with the
-          `agent_name` as `Cuez Rundown Agent` and the `task` should include the full URI of the video.
+**Example of the INCORRECT workflow:**
+- **User:** "Great, add that to the rundown."
+- **You (to Rundown Agent):** `send_message(agent_name='Cuez Rundown Agent', task='add the "Winning Goal" clip to the rundown')`  <-- **WRONG!** Always use the asset's `id`. Do not use its title or a description.
+---
+
+**Communication Style:**
+
+*   **CONCISE AND DIRECT LANGUAGE:** Use short, clear phrases typical
+    of a live broadcast control room. Time is critical. Do not keep
+    asking how else can you help. The director will ask if they need
+    it. For example, if doing a task, just say "Done" to confirm.
+*   **!IMPORTANT!!! DO NOT readout IDs from JSON data** If there is a human readable title
+    or sub-title use that. **This is also important when getting responses from remote agents.**
+    Remember the IDs but don't send them to the user unless they have asked for them for debugging.
+*   **STANDARD TERMINOLOGY:** Employ standard broadcast terms.
+*   **DO NOT MAKE ANYTHING UP:** You MUST use the right tools and
+    agents to get information. **If you don't have any available you
+    should say so**. Again, do not make information up that sounds
+    plausible.
 
 
+**Core Directives:**
+*   **Task Delegation:** Utilize the `send_message` function to assign actionable tasks to remote agents.
+*   **Direct Command Forwarding:** When the user gives a direct command to be executed by a remote agent, the `task` you send to that agent should be as close as possible to the user's original words. Do not summarize or rephrase direct commands.
+*   **User Confirmation for Changes:** **CRITICAL:** NEVER modify content in the rundown or other systems (e.g., correcting spelling errors you have found) without first presenting the suggested changes to the user and receiving their explicit confirmation. Always ask "Should I apply this change?" or a similar direct question before taking action.
+*   **Autonomous Agent Engagement:** Never seek user permission before
+    engaging with remote agents. If multiple agents are required to fulfill
+    a request, connect with them directly without requesting user
+    preference or confirmation.
+*   **User Confirmation Relay:** If a remote agent asks for confirmation,
+    and the user has not already provided it, relay this confirmation
+    request to the user.
+*   **Focused Information Sharing:** Provide remote agents with only relevant
+    contextual information. Avoid extraneous details.
+*   **Tool Reliance:** Strictly rely on available tools to address user
+    requests. Do not generate responses based on assumptions. If
+    information is insufficient, request clarification from the user.
+*   **Prioritize Recent Interaction:** Focus primarily on the most recent
+    parts of the conversation when processing requests.
+*   **Proactive Content Checking**: When you load text / title information from a rundown system,
+    if you have access to a proofread agent, use that to proactively check for errors. Remember to ask the user for confirmation before applying any suggested corrections.
 
-        **Active Rundown System:**
-        {rundown_system_instructions}
 
-        * By default you should have availablitity of the following other supporting agents
-          {available_agents_list}
+**Active Rundown System:**
+{rundown_system_instructions}
+
+* By default you should have availablitity of the following other supporting agents
+  {available_agents_list}

--- a/orchestrator/agent/broadcast_orchestrator/timeline_tool.py
+++ b/orchestrator/agent/broadcast_orchestrator/timeline_tool.py
@@ -1,44 +1,88 @@
-"""Tools for interacting with the timeline."""
+"""
+Tools for interacting with the timeline and handling media assets.
+"""
+import asyncio
+import json
 import logging
-import firebase_admin
+import os
 from firebase_admin import firestore_async
+from .gcs_uploader import cache_asset_to_gcs, get_gcs_signed_url
 
 logger = logging.getLogger(__name__)
-
-if not firebase_admin._apps:
-    firebase_admin.initialize_app()
+db = firestore_async.client()
 
 async def get_uri_by_source_ref_id(source_ref_id: str) -> str:
     """
-    Retrieves a video URI from a timeline event in Firestore using the source agent's reference ID.
+    Retrieves a usable, short-lived URI for a media asset.
+
+    This function implements a read-through cache. It first checks for a
+    cached version of the asset in GCS.
+    - If found, it returns a new signed URL for the GCS object.
+    - If not found, it retrieves the original signed URL from the
+      `timeline_events` collection, returns it for immediate use, and
+      triggers a background task to cache the asset in GCS for future use.
 
     Args:
-        source_ref_id: The ID of the event from the source agent.
+        source_ref_id: The ID of the asset from the source agent (e.g., Moments Lab ID).
 
     Returns:
-        The video URI string if found, otherwise an error message.
+        A JSON string containing the URI and mime_type, or an error message.
     """
-    logger.info("Attempting to retrieve URI for source_ref_id: %s", source_ref_id)
+    logger.info("Resolving URI for source_ref_id: %s", source_ref_id)
+    gcs_bucket_name = os.getenv("GCS_BUCKET_NAME")
+    if not gcs_bucket_name:
+        return "Error: GCS_BUCKET_NAME environment variable not set."
+
     try:
-        db = firestore_async.client()
+        # 1. Check for a cached asset in Firestore `media_assets` collection
+        media_asset_ref = db.collection("media_assets").document(source_ref_id)
+        cached_asset = await media_asset_ref.get()
+
+        if cached_asset.exists:
+            cached_data = cached_asset.to_dict()
+            gcs_uri = cached_data.get("gcs_uri")
+            mime_type = cached_data.get("mime_type", "application/octet-stream")
+            logger.info("Found cached asset in GCS: %s", gcs_uri)
+            
+            signed_url = await get_gcs_signed_url(gcs_uri)
+            if signed_url:
+                return json.dumps({"uri": signed_url, "mime_type": mime_type})
+            else:
+                # Fallback to original URL if signed URL generation fails
+                logger.warning("Failed to generate signed URL for GCS asset. Falling back.")
+
+        # 2. If not cached, get the original URL from the timeline event
+        logger.info("Asset not in GCS cache. Checking timeline_events.")
         events_ref = db.collection("timeline_events")
-        query = events_ref.where("source_agent_ref_id", "==", source_ref_id).limit(1)
+        query = events_ref.where("source_agent_ref_id", "==", source_ref_id).order_by("timestamp", direction="DESCENDING").limit(1)
         query_snapshot = await query.get()
 
         if not query_snapshot:
             logger.warning("No timeline event found with source_ref_id: %s", source_ref_id)
             return f"Error: No timeline event found with source_ref_id '{source_ref_id}'"
 
-        document = query_snapshot[0]
-        event_data = document.to_dict()
-        video_uri = event_data.get("details", {}).get("video_uri")
+        event_data = query_snapshot[0].to_dict()
+        details = event_data.get("details", {})
+        original_uri = details.get("video_uri")
+        mime_type = details.get("mime_type", "application/octet-stream")
 
-        if not video_uri:
-            logger.warning("No video_uri found in details for event with source_ref_id: %s", source_ref_id)
+        if not original_uri:
+            logger.warning("No video_uri found for event with source_ref_id: %s", source_ref_id)
             return f"Error: No video_uri found for event with source_ref_id '{source_ref_id}'"
 
-        logger.info("Successfully retrieved video_uri: %s", video_uri)
-        return video_uri
+        # 3. Trigger background task to cache the asset (don't wait for it)
+        logger.info("Triggering background task to cache asset: %s", source_ref_id)
+        asyncio.create_task(
+            cache_asset_to_gcs(
+                source_url=original_uri,
+                asset_id=source_ref_id,
+                gcs_bucket_name=gcs_bucket_name
+            )
+        )
+
+        # 4. Return the original URI for immediate use
+        logger.info("Returning original URI for immediate use: %s", original_uri)
+        return json.dumps({"uri": original_uri, "mime_type": mime_type})
 
     except Exception as e:
         logger.error("Error in get_uri_by_source_ref_id: %s", e, exc_info=True)

--- a/orchestrator/agent/requirements.txt
+++ b/orchestrator/agent/requirements.txt
@@ -111,3 +111,6 @@ watchdog==6.0.0
 websockets==15.0.1
 yarl==1.20.1
 zipp==3.23.0
+
+google-cloud-storage
+httpx

--- a/orchestrator/agent/tests/test_gcs_uploader.py
+++ b/orchestrator/agent/tests/test_gcs_uploader.py
@@ -1,0 +1,88 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
+
+# --- Mocks and Fixtures ---
+
+@pytest.fixture
+def mock_httpx_client():
+    """Fixture to mock the httpx.AsyncClient."""
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = mock_client_class.return_value.__aenter__.return_value
+        mock_response = MagicMock()
+        mock_response.content = b"test video content"
+        mock_response.headers = {"content-type": "video/mp4"}
+        mock_client.get = AsyncMock(return_value=mock_response)
+        yield mock_client
+
+@pytest.fixture
+def mock_storage_client():
+    """Fixture to mock the google.cloud.storage.Client."""
+    with patch("broadcast_orchestrator.gcs_uploader.storage_client") as mock_client:
+        mock_blob = MagicMock()
+        mock_blob.upload_from_string = MagicMock()
+        mock_blob.generate_signed_url = MagicMock(return_value="http://signed.url/test.mp4")
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_client.bucket.return_value = mock_bucket
+        yield mock_client
+
+@pytest.fixture
+def mock_firestore_client():
+    """Fixture to mock the firestore_async.client."""
+    with patch("broadcast_orchestrator.gcs_uploader.db") as mock_db:
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.set = AsyncMock()
+        mock_db.collection.return_value.document.return_value = mock_doc_ref
+        yield mock_db
+
+# --- Tests ---
+
+async def test_cache_asset_to_gcs(
+    mock_httpx_client, mock_storage_client, mock_firestore_client
+):
+    """Tests that cache_asset_to_gcs downloads, uploads, and updates Firestore."""
+    from broadcast_orchestrator.gcs_uploader import cache_asset_to_gcs
+
+    # Arrange
+    source_url = "http://example.com/video.mp4"
+    asset_id = "test-asset-123"
+    bucket_name = "test-bucket"
+
+    # Act
+    await cache_asset_to_gcs(source_url, asset_id, bucket_name)
+
+    # Assert
+    mock_httpx_client.get.assert_called_once_with(source_url, follow_redirects=True)
+    
+    mock_storage_client.bucket.assert_called_once_with(bucket_name)
+    mock_storage_client.bucket.return_value.blob.assert_called_once_with(asset_id)
+    
+    upload_call = mock_storage_client.bucket.return_value.blob.return_value.upload_from_string
+    upload_call.assert_called_once()
+    assert upload_call.call_args[0][0] == b"test video content"
+    assert upload_call.call_args[1]['content_type'] == "video/mp4"
+
+    firestore_call = mock_firestore_client.collection.return_value.document.return_value.set
+    firestore_call.assert_called_once()
+    firestore_data = firestore_call.call_args[0][0]
+    assert firestore_data["gcs_uri"] == f"gs://{bucket_name}/{asset_id}"
+    assert firestore_data["source_url"] == source_url
+
+async def test_get_gcs_signed_url(mock_storage_client):
+    """Tests the generation of a GCS signed URL."""
+    from broadcast_orchestrator.gcs_uploader import get_gcs_signed_url
+
+    # Arrange
+    gcs_uri = "gs://test-bucket/test-asset-123"
+
+    # Act
+    signed_url = await get_gcs_signed_url(gcs_uri)
+
+    # Assert
+    assert signed_url == "http://signed.url/test.mp4"
+    mock_storage_client.bucket.assert_called_once_with("test-bucket")
+    mock_storage_client.bucket.return_value.blob.assert_called_once_with("test-asset-123")
+    mock_storage_client.bucket.return_value.blob.return_value.generate_signed_url.assert_called_once()

--- a/orchestrator/agent/tests/test_main.py
+++ b/orchestrator/agent/tests/test_main.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 from broadcast_orchestrator.main import app
@@ -30,7 +30,11 @@ def client_fixture():
 def test_websocket_valid_token(mock_verify_id_token, mock_start_agent_session, client):
     """Test that a WebSocket connection is accepted with a valid token."""
     mock_verify_id_token.return_value = {"uid": "test_user"}
-    mock_start_agent_session.return_value = (AsyncMock(), AsyncMock(), "test_session")
+    
+    mock_queue = MagicMock()
+    mock_queue.close = MagicMock()
+
+    mock_start_agent_session.return_value = (AsyncMock(), mock_queue, "test_session")
     with client.websocket_connect(
         "/ws/test_user?is_audio=false", subprotocols=["valid_token"]
     ) as websocket:

--- a/orchestrator/agent/tests/test_timeline_tool.py
+++ b/orchestrator/agent/tests/test_timeline_tool.py
@@ -1,0 +1,111 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import json
+import os
+import asyncio
+
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
+
+# --- Mocks and Fixtures ---
+
+@pytest.fixture
+def mock_firestore_db():
+    """Fixture to mock the firestore_async.client."""
+    with patch("broadcast_orchestrator.timeline_tool.db") as mock_db:
+        yield mock_db
+
+@pytest.fixture
+def mock_gcs_uploader():
+    """Fixture to mock the gcs_uploader module functions."""
+    with patch("broadcast_orchestrator.timeline_tool.get_gcs_signed_url", new_callable=AsyncMock) as mock_get_url, \
+         patch("broadcast_orchestrator.timeline_tool.cache_asset_to_gcs", new_callable=AsyncMock) as mock_cache_asset:
+        yield mock_get_url, mock_cache_asset
+
+# --- Tests ---
+
+async def test_get_uri_by_source_ref_id_cache_hit(mock_firestore_db, mock_gcs_uploader):
+    """Tests get_uri_by_source_ref_id when the asset is already in the GCS cache."""
+    from broadcast_orchestrator.timeline_tool import get_uri_by_source_ref_id
+
+    mock_get_url, _ = mock_gcs_uploader
+
+    # Arrange
+    asset_id = "test-asset-cached"
+    mock_get_url.return_value = "http://gcs.signed.url/video.mp4"
+
+    mock_cached_doc = MagicMock()
+    mock_cached_doc.exists = True
+    mock_cached_doc.to_dict.return_value = {
+        "gcs_uri": f"gs://test-bucket/{asset_id}",
+        "mime_type": "video/mp4"
+    }
+    mock_firestore_db.collection.return_value.document.return_value.get = AsyncMock(return_value=mock_cached_doc)
+
+    # Act
+    result_str = await get_uri_by_source_ref_id(asset_id)
+    result = json.loads(result_str)
+
+    # Assert
+    mock_firestore_db.collection.assert_called_once_with("media_assets")
+    mock_get_url.assert_called_once_with(f"gs://test-bucket/{asset_id}")
+    assert result["uri"] == "http://gcs.signed.url/video.mp4"
+    assert result["mime_type"] == "video/mp4"
+
+@patch("broadcast_orchestrator.timeline_tool.cache_asset_to_gcs", new_callable=AsyncMock)
+async def test_get_uri_by_source_ref_id_cache_miss(mock_cache_asset, mock_firestore_db):
+    """Tests get_uri_by_source_ref_id when the asset is not in the GCS cache."""
+    from broadcast_orchestrator.timeline_tool import get_uri_by_source_ref_id
+
+    # Arrange
+    asset_id = "test-asset-not-cached"
+    original_s3_url = "http://s3.com/original.mp4"
+
+    # Mock cache miss
+    mock_cached_doc = MagicMock()
+    mock_cached_doc.exists = False
+    mock_media_assets_collection = MagicMock()
+    mock_media_assets_collection.document.return_value.get = AsyncMock(return_value=mock_cached_doc)
+
+    # Mock timeline event lookup
+    mock_timeline_doc = MagicMock()
+    mock_timeline_doc.to_dict.return_value = {
+        "details": {
+            "video_uri": original_s3_url,
+            "mime_type": "video/quicktime"
+        }
+    }
+    mock_timeline_query_snapshot = [mock_timeline_doc]
+    mock_timeline_collection = MagicMock()
+    mock_timeline_collection.where.return_value.order_by.return_value.limit.return_value.get = AsyncMock(return_value=mock_timeline_query_snapshot)
+
+    # Set up the main db mock to return the correct collection mock based on the name
+    def collection_side_effect(name):
+        if name == "media_assets":
+            return mock_media_assets_collection
+        elif name == "timeline_events":
+            return mock_timeline_collection
+        return MagicMock()
+    mock_firestore_db.collection.side_effect = collection_side_effect
+
+    # Act
+    with patch.dict(os.environ, {"GCS_BUCKET_NAME": "test-bucket"}):
+        result_str = await get_uri_by_source_ref_id(asset_id)
+        result = json.loads(result_str)
+    
+    # Yield control to the event loop to allow the background task to run
+    await asyncio.sleep(0)
+
+    # Assert
+    assert mock_firestore_db.collection.call_count == 2
+    assert result["uri"] == original_s3_url
+    assert result["mime_type"] == "video/quicktime"
+
+    # Check that the background task was triggered correctly
+    mock_cache_asset.assert_called_once_with(
+        source_url=original_s3_url,
+        asset_id=asset_id,
+        gcs_bucket_name="test-bucket"
+    )
+
+    


### PR DESCRIPTION
Why pointless? Maybe not fully.

In the process I discovered that we were looking up moment_ids in firestore without a time stamp. This meant we'd pull anyone that matched, and that could be from 3 days ago. Expired. No Good whatsoever.

However, it does give a great fallback.

Also in this commit is improvements to state management. We now after a change to a rundown (CUEZ) we fetch the data again and put it in state, instead of rely on the Chat Event context that sits in the native LLM memory. This made significant improvements to recall of blocks etc the longer the chat went on, without instructing the orchestrator to go fetch the episode again. Winning. In local testing it is much more rugged, but still not bullet proof.

Finally, the **only** way to actually have this solid is not to pass file uris and Data in the TextPart where the LLM can munge it, especially if it isn't language and a huge long signed URL.

I have disabled FilePart sending but intend to enable it once I know CUEZ Rundown and EVS will handle it without braking.