### PR TITLE
Fix the video URI problem.

### DIFF
--- a/orchestrator/agent/broadcast_orchestrator/system_instructions.txt
+++ b/orchestrator/agent/broadcast_orchestrator/system_instructions.txt
@@ -8,7 +8,7 @@ specialized remote agents.
 Failure to follow this rule will cause the entire system to fail.
 
 1.  **RECEIVE ID:** When a remote agent (e.g., Moments Lab Agent) gives you a file or video clip, its response will contain a reference `id` (like `moment_id` or a similar unique identifier).
-2.  **REMEMBER ID:** You MUST remember this `id`.
+2.  **REMEMBER ID:** You MUST remember this `id` for future tool calls. Internally, you should associate any asset you find with its unique `id` (e.g., `68af3216ccca924fcfe93056`). This ID is your primary reference for the asset.
 3.  **SEND ID:** When you need to use that file in a later step (e.g., sending it to the rundown agent), you MUST call the `send_message` tool with a `task` that includes the `id` you remembered. Use a clear phrase like `add clip with id <id>`.
 
 **You should NOT call the `get_uri_by_source_ref_id` tool yourself.** The `send_message` tool will handle this automatically.
@@ -17,13 +17,20 @@ Failure to follow this rule will cause the entire system to fail.
 - **User:** "Find me a clip of the winning goal."
 - **You (to Moments Lab Agent):** `send_message(agent_name='Moments Lab', task='find winning goal')`
 - **Moments Lab Agent (in response):** A JSON object containing `... "title": "Winning Goal", "id": "moment_abc_123" ...`
-- **You (thinking):** *I have received a clip. I must remember the id: "moment_abc_123".*
+- **You (thinking):** *I have received a clip. I must remember the id: "moment_abc_123" for future tool calls.*
 - **User:** "Great, add that to the rundown."
 - **You (to Rundown Agent):** `send_message(agent_name='Cuez Rundown Agent', task='add clip with id moment_abc_123')`
 
 **Example of the INCORRECT workflow:**
 - **User:** "Great, add that to the rundown."
 - **You (to Rundown Agent):** `send_message(agent_name='Cuez Rundown Agent', task='add the "Winning Goal" clip to the rundown')`  <-- **WRONG!** Always use the asset's `id`. Do not use its title or a description.
+---
+
+**CRITICAL OUTPUT RULE: DO NOT embed long URLs directly in your natural language responses to the user.**
+-   If you need to refer to a video, use its title or a short description.
+-   The UI will handle displaying the actual playable link.
+-   For example, instead of "You can view the video here: `https://long-url.mp4`", say "I found the video titled 'Measles Outbreak'. You can view it in the player."
+
 ---
 
 **Communication Style:**

--- a/orchestrator/agent/broadcast_orchestrator/timeline_manager.py
+++ b/orchestrator/agent/broadcast_orchestrator/timeline_manager.py
@@ -250,9 +250,17 @@ async def process_tool_output_for_timeline(**kwargs):
         if not tool_response or not isinstance(tool_response, list):
             return
 
-        # The tool_response is a list of JSON strings, each representing a part.
-        # We need to parse them into a list of dictionaries.
-        all_parts = [json.loads(item) for item in tool_response]
+        # Pre-filter for items that look like JSON objects or arrays to avoid parse errors
+        json_items = [
+            item for item in tool_response 
+            if isinstance(item, str) and item.strip().startswith(('{', '['))
+        ]
+
+        if not json_items:
+            logger.info("No valid JSON items found in tool_response for timeline processing.")
+            return
+
+        all_parts = [json.loads(item) for item in json_items]
         all_events = []
 
         if "posture" in remote_agent_name:


### PR DESCRIPTION
Tried not giving the LLM one, and it would Hallucinate one, so the solution...

To intercept the payload and remove it with something that contains the asset ID and looks like a video URI. It is short. The LLM gets it correct.

Store it in state (we already store in firestore as a backup).

Look for that uri in requests to other agents, and swap it out with correct URI.

Solved on orchestrator side. But still failed with some agents, because their model was also munging the URI, added FilePart for the other agents to get the video_uri from which doesn't touch the LLM.