### PR TITLE
fix: remove unregistered a2a-framework dependency (dependency confusion)

### DIFF
--- a/shure-audio-agent/requirements.txt
+++ b/shure-audio-agent/requirements.txt
@@ -1,6 +1,3 @@
-# A2A Framework dependencies
-a2a-framework>=1.0.0
-
 # ADK dependencies
 google-adk>=1.0.0
 


### PR DESCRIPTION
`shure-audio-agent/requirements.txt` lists `a2a-framework>=1.0.0`, which is not a registered package on PyPI. The `>=1.0.0` constraint means any version an attacker publishes satisfies it.

The package appears next to `google-adk` (Google's Agent Development Kit), giving it an authoritative appearance. An attacker who registers `a2a-framework` on PyPI gains code execution in an AI agent pipeline with access to audio stream data, hardware control interfaces, and API credentials.

This PR removes the `a2a-framework` entry. If the A2A SDK is available under a different registered PyPI name (e.g. `google-a2a-sdk`), please replace with the correct name.
