### PR TITLE
SomHackathon: Add content_refs and /api/content endpoint for story body text

### DIFF
--- a/som-hackathon-starter-dotnet/.env.example
+++ b/som-hackathon-starter-dotnet/.env.example
@@ -1,0 +1,16 @@
+# Confluent Cloud cluster
+KAFKA_BOOTSTRAP_SERVERS=pkc-xxxxx.us-central1.gcp.confluent.cloud:9092
+KAFKA_API_KEY=your-api-key-here
+KAFKA_API_SECRET=your-api-secret-here
+
+# AI review (Layer 3) — set one of these to enable LLM-based skill review
+# Gemini is preferred (Google is providing keys for IBC 2026)
+# GOOGLE_API_KEY=AIza...your-key-here
+# GEMINI_MODEL=gemini-2.0-flash
+
+# Anthropic fallback (if no Google key)
+# ANTHROPIC_API_KEY=sk-ant-...your-key-here
+# ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+
+# Optional: override the dashboard listener (default 5050)
+# ASPNETCORE_URLS=http://+:5050

--- a/som-hackathon-starter-dotnet/Dockerfile
+++ b/som-hackathon-starter-dotnet/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 COPY --from=build /app .
 COPY seed-stories/ seed-stories/
 COPY skills/ skills/
+COPY content/ content/
 ENV ASPNETCORE_URLS=http://+:5050
 EXPOSE 5050
 ENTRYPOINT ["dotnet", "SomSkillWorker.dll"]

--- a/som-hackathon-starter-dotnet/Program.cs
+++ b/som-hackathon-starter-dotnet/Program.cs
@@ -157,6 +157,30 @@ app.MapGet("/api/seed-stories/{scenario}", async (string scenario) =>
         : Results.Content(json, "application/json");
 });
 
+// ── Content endpoint (story body behind content_ref) ──
+// Resolution order differs from TestProducer.ResolveSeedPath because the published
+// container has content/ next to the DLL (BaseDirectory) per the Dockerfile, while
+// `dotnet run` has it three levels up at the project root.
+app.MapGet("/api/content/{storyId}", async (string storyId) =>
+{
+    // Reject anything that isn't a plain story-id slug. Path.Combine doesn't normalise
+    // ".." segments, so without this an attacker could walk out of content/ and read
+    // arbitrary .txt files on disk.
+    if (!System.Text.RegularExpressions.Regex.IsMatch(storyId, @"^[A-Za-z0-9_-]+$"))
+        return Results.BadRequest(new { error = "invalid_story_id" });
+
+    var relPath = Path.Combine("content", $"{storyId}.txt");
+    var sourceTreePath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", relPath);
+    var publishedPath = Path.Combine(AppContext.BaseDirectory, relPath);
+    var file = File.Exists(sourceTreePath) ? sourceTreePath
+             : File.Exists(publishedPath) ? publishedPath
+             : null;
+    if (file is null)
+        return Results.NotFound(new { error = "content_not_found", story_id = storyId });
+    var body = await File.ReadAllTextAsync(file);
+    return Results.Text(body, "text/plain; charset=utf-8");
+});
+
 app.MapPost("/api/decision/{id}", async (
     string id,
     DecisionRequest body,

--- a/som-hackathon-starter-dotnet/README.md
+++ b/som-hackathon-starter-dotnet/README.md
@@ -117,7 +117,8 @@ The skill worker never publishes directly to `som.skills.events`. Every output f
 | `Program.cs` | ASP.NET WebApplication. Hosts all background services + maps REST/WS endpoints + serves static files. |
 | `KafkaOptions.cs` | POCO bound from `appsettings.json`. |
 | `wwwroot/index.html` | Dashboard SPA — single file, no build step. |
-| `seed-stories/*.json` | Five SOM v0.2 envelopes for demo scenarios. |
+| `seed-stories/*.json` | Five SOM v0.2 envelopes for demo scenarios (each includes `content_refs[]`). |
+| `content/*.txt` | Canned story body text served by `GET /api/content/{storyId}`. |
 | `appsettings.json` | Local dev config (Plaintext + localhost broker). |
 | `appsettings.Production.json` | Confluent Cloud SaslSsl placeholders, populated from env vars. |
 | `docker-compose.yml` | Local KRaft Kafka + Kafka UI on port 8080. |
@@ -164,7 +165,11 @@ Five SOM v0.2 envelopes in `seed-stories/`, modeled on real broadcast scenarios:
 | `clean` | City Council Approves $2.1 Billion Public Transit Expansion | PUBLISHED | Clean copy — no warnings expected |
 | `election` | Virginia Governor Race Too Close to Call as Polls Close | DEVELOPING | Standard developing story — no warnings expected |
 
-Each envelope is a full SOM v0.2 message (`som_version`, `message_id`, `correlation_id`, `source`, `payload`) with rich `payload` fields including `lifecycle`, `priority`, `premise`, `compliance[]`, `editorial_gates[]`, `sources[]`, `assets[]`, `ai_enrichments[]`, `instances[]`, and `skills_config`.
+Each envelope is a full SOM v0.2 message (`som_version`, `message_id`, `correlation_id`, `source`, `payload`) with rich `payload` fields including `lifecycle`, `priority`, `premise`, `compliance[]`, `editorial_gates[]`, `sources[]`, `assets[]`, `ai_enrichments[]`, `instances[]`, `skills_config`, and `content_refs[]`.
+
+### content_refs
+
+Each seed story includes a `content_refs` array pointing to `GET /api/content/{story_id}`, which serves canned body text from `content/*.txt`. This matches AP's wire shape where the Kafka message carries metadata only and the full story body lives behind a URI. Each entry includes a `source_id` linking back to the `sources[]` array for provenance. Skills that need the full text (fact-checking, summarization, NLP) should fetch from `content_refs[].uri`.
 
 ## Kafka topics
 

--- a/som-hackathon-starter-dotnet/content/election-special-2026-0615.txt
+++ b/som-hackathon-starter-dotnet/content/election-special-2026-0615.txt
@@ -1,0 +1,11 @@
+The Virginia governor's race remained too close to call late Tuesday night as returns from key suburban counties trickled in, with the margin between the two candidates hovering under one percentage point.
+
+With 62 percent of precincts reporting statewide, Republican nominee James Whitfield held a narrow lead of 0.8 points over Democratic nominee Angela Torres. Both campaigns told supporters to expect a long night.
+
+The outcome hinges on outstanding vote from Northern Virginia's populous Fairfax County, where only 23 percent of precincts have reported, and Virginia Beach, at 41 percent reported. Both jurisdictions have historically played decisive roles in statewide races.
+
+Exit polls, released after all Virginia precincts closed at 7:00 PM Eastern, showed the economy and education as the top issues for voters. Torres led among voters who cited education, while Whitfield had an advantage on economic concerns.
+
+Neither the Associated Press nor any major network decision desk has projected a winner. The Virginia Secretary of State's office said a full count could extend into early Wednesday morning given the volume of same-day registrations under the state's new automatic voter registration law.
+
+Both candidates addressed supporters briefly, urging patience as votes continued to be tallied across the commonwealth's 133 localities.

--- a/som-hackathon-starter-dotnet/content/lapd-counterfeit-2026-0510.txt
+++ b/som-hackathon-starter-dotnet/content/lapd-counterfeit-2026-0510.txt
@@ -1,0 +1,11 @@
+LAPD officers arrested multiple individuals Saturday in connection with a counterfeit sneaker operation in the downtown Fashion District, authorities said.
+
+Detectives from the Commercial Crimes Division executed search warrants at three storefronts along Los Angeles Street, seizing an estimated 4,200 pairs of counterfeit athletic shoes with a retail value exceeding $800,000 if genuine, according to an LAPD spokesperson.
+
+Some of those detained are minors, police confirmed, though they declined to provide further details about the juvenile suspects citing California privacy laws. Adult suspects were booked on charges including trademark counterfeiting and possession of counterfeit goods for sale.
+
+The operation was the culmination of a two-month investigation prompted by complaints from major athletic footwear brands. Undercover officers made multiple controlled purchases before obtaining the warrants.
+
+Counterfeit goods ranging from sneakers to handbags have been a persistent enforcement challenge in the Fashion District, a 90-block area that serves as the hub of LA's garment and wholesale trade. Industry groups estimate counterfeit merchandise costs legitimate retailers billions annually nationwide.
+
+Arraignment dates for the adult suspects have not yet been scheduled. The investigation remains ongoing and additional arrests are possible, police said.

--- a/som-hackathon-starter-dotnet/content/manhattan-explosion-2026-0506.txt
+++ b/som-hackathon-starter-dotnet/content/manhattan-explosion-2026-0506.txt
@@ -1,0 +1,11 @@
+A large explosion rocked a commercial building in lower Manhattan Wednesday evening, sending a plume of smoke visible across the Hudson River and prompting a massive emergency response.
+
+The blast occurred at approximately 5:47 PM in a six-story mixed-use building on Greenwich Street near the Battery Park City border, according to FDNY officials. At least 12 people were transported to area hospitals with injuries ranging from minor cuts to serious burns.
+
+Fire crews arriving on scene found heavy fire conditions on the third and fourth floors with partial structural collapse of the building's facade. A second alarm was transmitted within minutes, eventually escalating to a five-alarm response with more than 200 firefighters deployed.
+
+The cause of the explosion remains under investigation. Con Edison reported no active gas leaks at the address, though investigators have not ruled out a gas-related incident. NTSB officials said they are monitoring the situation.
+
+Greenwich Street was closed from Rector Street to Battery Place, and the nearby 1 train Rector Street station was temporarily bypassed. The Office of Emergency Management advised residents in the immediate area to shelter in place until air quality monitoring could be completed.
+
+Mayor's office officials said the building had been cited for two open building code violations but that neither was related to gas infrastructure.

--- a/som-hackathon-starter-dotnet/content/sentencing-2026-0401.txt
+++ b/som-hackathon-starter-dotnet/content/sentencing-2026-0401.txt
@@ -1,0 +1,11 @@
+A federal jury returned a surprise not-guilty verdict Tuesday in the fraud trial of Robert Jones, overturning months of legal expectations that pointed toward conviction and prison time.
+
+The verdict came after nearly four days of deliberation in U.S. District Court in Manhattan. Jones, 54, had been charged with three counts of wire fraud and two counts of securities fraud in connection with an alleged scheme to inflate quarterly earnings at his former company, Meridian Capital Partners.
+
+Prosecutors argued that Jones directed subordinates to book fictitious revenue from shell entities, artificially boosting share price ahead of a planned secondary offering. The government called 14 witnesses and introduced hundreds of pages of internal emails during the three-week trial.
+
+Defense attorney Sarah Chen told reporters outside the courthouse that the jury "saw through a case built on circumstantial inference." She said Jones would seek to have the related SEC civil action dismissed in light of the acquittal.
+
+The outcome stunned courtroom observers. Legal analysts had widely predicted conviction based on the strength of the documentary evidence and cooperating witness testimony.
+
+Jones faces no further criminal charges. The SEC civil case remains pending in the Southern District of New York.

--- a/som-hackathon-starter-dotnet/content/transit-expansion-2026-0512.txt
+++ b/som-hackathon-starter-dotnet/content/transit-expansion-2026-0512.txt
@@ -1,0 +1,11 @@
+New York's Metropolitan Transportation Authority announced a $3.7 billion plan Monday to extend subway service to underserved neighborhoods in eastern Queens, marking the agency's most ambitious expansion proposal in more than a decade.
+
+The plan calls for a 4.2-mile extension of the 7 line from its current terminus at Flushing-Main Street eastward to Fresh Meadows, adding three new stations. MTA officials said the project would bring direct subway access to approximately 180,000 residents who currently rely on buses for their commutes.
+
+Governor Sarah Mitchell called the proposal "a generational investment in transit equity" at a press conference at Queens Borough Hall. The project would be funded through a combination of federal infrastructure grants, state capital allocations, and revenue from the congestion pricing program that took effect earlier this year.
+
+Construction would begin in 2028 with an estimated completion date of 2034, according to the MTA's preliminary engineering study. The timeline assumes timely environmental review and federal funding approval.
+
+Community groups in the affected neighborhoods expressed cautious optimism. Local transit advocates have lobbied for improved rail access to eastern Queens for more than 20 years, arguing that bus-dependent commuters face significantly longer travel times to Manhattan job centers.
+
+The MTA board is expected to vote on advancing the project to the environmental review phase at its June meeting.

--- a/som-hackathon-starter-dotnet/docs/som-v02-envelope.md
+++ b/som-hackathon-starter-dotnet/docs/som-v02-envelope.md
@@ -198,6 +198,24 @@ Broadcaster-defined metadata about which skills should run against this story.
 | `skills_config.active_skills[].migration_policy` | string | `"hot"`, `"cold"`, `"gated"` |
 | `skills_config.active_skills[].skill_priority` | string | `"critical"`, `"normal"`, `"low"` |
 
+## `content_refs[]`
+
+Array of references to story body content. The SOM message on Kafka carries metadata only — the actual body lives behind URIs listed here. Skills that need to process story text (fact-checking, summarization, etc.) fetch from the `uri` field.
+
+| Path | Type | Required | Description |
+|------|------|----------|-------------|
+| `content_refs[].uri` | string | yes | URL to fetch the story body |
+| `content_refs[].mime_type` | string | no | MIME type of the body (e.g. `"text/plain"`) |
+| `content_refs[].content_format` | string | no | Content format identifier (reserved for future use) |
+| `content_refs[].placement` | string | no | Where this content fits (e.g. `"sources"`) |
+| `content_refs[].provider` | string | no | Who provided this content (e.g. `"AP"`, `"NBCU"`) |
+| `content_refs[].role` | string | no | Role of this content reference (reserved for future use) |
+| `content_refs[].source_id` | string | no | Links back to a `sources[].source_id` for provenance |
+
+In the local dev environment, the starter serves canned body text at `GET /api/content/{story_id}` with open access. On hackathon day, AP will host content behind their own URLs (also open access for the hackathon).
+
+The `content/` directory contains `.txt` files keyed by `story_id` that the local endpoint serves. To add body text for a new seed story, drop a `{story_id}.txt` file in that directory.
+
 ## Using field paths in rules
 
 The rule engine accesses fields via dot-notation paths relative to the payload root. Examples:

--- a/som-hackathon-starter-dotnet/seed-stories/01-breaking-courthouse.json
+++ b/som-hackathon-starter-dotnet/seed-stories/01-breaking-courthouse.json
@@ -172,6 +172,17 @@
       ]
     },
     "updated_at": "2026-04-01T14:45:12Z",
-    "sequence_number": 47
+    "sequence_number": 47,
+    "content_refs": [
+      {
+        "content_format": null,
+        "mime_type": "text/plain",
+        "placement": "sources",
+        "provider": "NBCU",
+        "role": null,
+        "source_id": "src-ap-20260401-1444",
+        "uri": "http://localhost:5050/api/content/sentencing-2026-0401"
+      }
+    ]
   }
 }

--- a/som-hackathon-starter-dotnet/seed-stories/02-developing-election.json
+++ b/som-hackathon-starter-dotnet/seed-stories/02-developing-election.json
@@ -207,6 +207,17 @@
       ]
     },
     "updated_at": "2026-06-15T21:30:00Z",
-    "sequence_number": 134
+    "sequence_number": 134,
+    "content_refs": [
+      {
+        "content_format": null,
+        "mime_type": "text/plain",
+        "placement": "sources",
+        "provider": "NBCU",
+        "role": null,
+        "source_id": "src-ap-election-feed",
+        "uri": "http://localhost:5050/api/content/election-special-2026-0615"
+      }
+    ]
   }
 }

--- a/som-hackathon-starter-dotnet/seed-stories/03-informal-headline.json
+++ b/som-hackathon-starter-dotnet/seed-stories/03-informal-headline.json
@@ -146,6 +146,17 @@
       ]
     },
     "updated_at": "2026-05-10T16:20:00Z",
-    "sequence_number": 12
+    "sequence_number": 12,
+    "content_refs": [
+      {
+        "content_format": null,
+        "mime_type": "text/plain",
+        "placement": "sources",
+        "provider": "NBCU",
+        "role": null,
+        "source_id": "src-lapd-pio",
+        "uri": "http://localhost:5050/api/content/lapd-counterfeit-2026-0510"
+      }
+    ]
   }
 }

--- a/som-hackathon-starter-dotnet/seed-stories/04-clean-transit.json
+++ b/som-hackathon-starter-dotnet/seed-stories/04-clean-transit.json
@@ -191,6 +191,17 @@
       ]
     },
     "updated_at": "2026-05-12T11:00:00Z",
-    "sequence_number": 8
+    "sequence_number": 8,
+    "content_refs": [
+      {
+        "content_format": null,
+        "mime_type": "text/plain",
+        "placement": "sources",
+        "provider": "NBCU",
+        "role": null,
+        "source_id": "src-mta-presser",
+        "uri": "http://localhost:5050/api/content/transit-expansion-2026-0512"
+      }
+    ]
   }
 }

--- a/som-hackathon-starter-dotnet/seed-stories/05-breaking-no-compliance.json
+++ b/som-hackathon-starter-dotnet/seed-stories/05-breaking-no-compliance.json
@@ -88,6 +88,17 @@
       ]
     },
     "updated_at": "2026-05-06T18:02:14Z",
-    "sequence_number": 1
+    "sequence_number": 1,
+    "content_refs": [
+      {
+        "content_format": null,
+        "mime_type": "text/plain",
+        "placement": "sources",
+        "provider": "NBCU",
+        "role": null,
+        "source_id": "src-fdny-pio",
+        "uri": "http://localhost:5050/api/content/manhattan-explosion-2026-0506"
+      }
+    ]
   }
 }

--- a/som-hackathon-starter-dotnet/starters/node/README.md
+++ b/som-hackathon-starter-dotnet/starters/node/README.md
@@ -76,6 +76,19 @@ Five SOM v0.2 envelopes in `../../seed-stories/` (shared with all starters):
 | `clean` | Clean copy — no warnings expected |
 | `election` | Developing story — no warnings expected |
 
+### Fetching story body text (content_refs)
+
+Each seed story includes a `content_refs` array with URIs pointing to story body text. Locally these resolve to `GET /api/content/{story_id}` on the .NET dashboard (port 5050). On hackathon day, AP stories will point to AP-hosted URLs (open access).
+
+```typescript
+const refs = payload.content_refs ?? [];
+for (const ref of refs) {
+  const resp = await fetch(ref.uri);
+  const body = await resp.text();
+  // ref.source_id links back to payload.sources[] for provenance
+}
+```
+
 ## Confluent Cloud
 
 Set env vars from `.env.example`:

--- a/som-hackathon-starter-dotnet/starters/python/README.md
+++ b/som-hackathon-starter-dotnet/starters/python/README.md
@@ -76,6 +76,19 @@ Five SOM v0.2 envelopes in `../../seed-stories/` (shared with all starters):
 | `clean` | Clean copy — no warnings expected |
 | `election` | Developing story — no warnings expected |
 
+### Fetching story body text (content_refs)
+
+Each seed story includes a `content_refs` array with URIs pointing to story body text. Locally these resolve to `GET /api/content/{story_id}` on the .NET dashboard (port 5050). On hackathon day, AP stories will point to AP-hosted URLs (open access).
+
+```python
+import httpx
+
+for ref in payload.get("content_refs", []):
+    resp = httpx.get(ref["uri"])
+    body = resp.text  # plain-text story
+    # ref["source_id"] links back to payload["sources"] for provenance
+```
+
 ## Confluent Cloud
 
 Set env vars from `.env.example`:


### PR DESCRIPTION
## Summary
- Adds SOM v0.2 `content_refs[]` to all five seed stories, pointing at `GET /api/content/{story_id}` on the local dashboard. Matches AP's wire shape where the Kafka message carries metadata only and the full body lives behind a URI.
- New `/api/content/{storyId}` endpoint serves canned bodies from `content/*.txt`. Path resolution works for both `dotnet run` (project-root layout) and the published container (`content/` next to the DLL), mirroring `TestProducer.ResolveSeedPath`.
- `storyId` is validated against `^[A-Za-z0-9_-]+$` before any disk access so URL-decoded `..` can't escape the content directory.
- Dockerfile copies `content/` into the image.
- Documents `content_refs` in `README.md`, `docs/som-v02-envelope.md`, and `starters/{node,python}/README.md`.
- Adds `.env.example` for Confluent Cloud + AI provider keys.

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet run` locally
  - [x] `GET /api/content/sentencing-2026-0401` → 200 + body, `text/plain; charset=utf-8`
  - [x] `GET /api/content/no-such-story` → 404 `content_not_found`
  - [x] `GET /api/content/..%2F..%2F..%2Fappsettings` → 400 `invalid_story_id`
  - [x] `GET /api/content/foo.bar` → 400 (regex rejects `.`)
  - [x] `GET /api/seed-stories/breaking` includes `content_refs[]` with the right URI + `source_id`
- [x] Container (`docker build .` + `docker run -p 5050:5050 -e ASPNETCORE_ENVIRONMENT=Development`)
  - [x] `/app/content/` populated with all five `.txt` files
  - [x] Valid story ID → 200 + body (proves `BaseDirectory + content/` fallback works inside the container)
  - [x] Path traversal → 400, unknown ID → 404