### PR TITLE
SOM v0.2.1-hackathon deliverables (D-002b, D-009, D-010, D-011)

### DIFF
--- a/som-hackathon-starter-dotnet/SkillDefinition.cs
+++ b/som-hackathon-starter-dotnet/SkillDefinition.cs
@@ -23,6 +23,8 @@ public sealed record SkillDefinition(
 /// <summary>
 /// One detection rule inside a skill. The Type discriminator selects which
 /// RuleEngine evaluator runs; Config is the type-specific payload.
+/// Citations and Rationale, when present, are surfaced on the
+/// skill.warning.raised message under extensions.com.nbcu (D-002b).
 /// </summary>
 public sealed record SkillRule(
     [property: JsonPropertyName("rule_id")] string RuleId,
@@ -33,7 +35,16 @@ public sealed record SkillRule(
     [property: JsonPropertyName("default_severity")] string DefaultSeverity,
     [property: JsonPropertyName("output_message_type")] string OutputMessageType,
     [property: JsonPropertyName("affected_fields")] string[] AffectedFields,
-    [property: JsonPropertyName("detail_template")] string? DetailTemplate);
+    [property: JsonPropertyName("detail_template")] string? DetailTemplate,
+    [property: JsonPropertyName("citations")] Citation[]? Citations = null,
+    [property: JsonPropertyName("rationale")] string? Rationale = null);
+
+/// <summary>
+/// Backing material for a SkillWarning, emitted under extensions.com.nbcu.citations.
+/// </summary>
+public sealed record Citation(
+    [property: JsonPropertyName("source_id")] string SourceId,
+    [property: JsonPropertyName("quote")] string Quote);
 
 public static class SkillDefinitionJson
 {

--- a/som-hackathon-starter-dotnet/SkillWorker.cs
+++ b/som-hackathon-starter-dotnet/SkillWorker.cs
@@ -131,7 +131,7 @@ public class SkillWorker : BackgroundService
     private static JsonNode BuildWarning(SkillDefinition skill, RuleMatch match, string storyId)
     {
         var rule = match.Rule;
-        return new JsonObject
+        var warning = new JsonObject
         {
             ["message_type"] = rule.OutputMessageType,
             ["warning_id"] = Guid.NewGuid().ToString(),
@@ -147,6 +147,34 @@ public class SkillWorker : BackgroundService
             ["blocks"] = new JsonArray(),
             ["timestamp"] = DateTimeOffset.UtcNow.ToString("o"),
         };
+
+        var extensions = BuildExtensions(rule);
+        if (extensions is not null) warning["extensions"] = extensions;
+
+        return warning;
+    }
+
+    /// <summary>
+    /// Build the per-warning extensions block (D-002b). Emits flat-key
+    /// extensions.com.nbcu.citations and extensions.com.nbcu.rationale when
+    /// the rule definition supplies them. Returns null if neither is set.
+    /// </summary>
+    private static JsonObject? BuildExtensions(SkillRule rule)
+    {
+        var hasCitations = rule.Citations is { Length: > 0 };
+        var hasRationale = !string.IsNullOrWhiteSpace(rule.Rationale);
+        if (!hasCitations && !hasRationale) return null;
+
+        var ext = new JsonObject();
+        if (hasCitations)
+        {
+            var arr = new JsonArray();
+            foreach (var c in rule.Citations!)
+                arr.Add(new JsonObject { ["source_id"] = c.SourceId, ["quote"] = c.Quote });
+            ext["com.nbcu.citations"] = arr;
+        }
+        if (hasRationale) ext["com.nbcu.rationale"] = rule.Rationale!;
+        return ext;
     }
 
     /// <summary>Build skill.run.completed audit record (Amendment 1, hackathon brief §8.1).</summary>

--- a/som-hackathon-starter-dotnet/docs/message-contracts.md
+++ b/som-hackathon-starter-dotnet/docs/message-contracts.md
@@ -23,6 +23,47 @@ Use the **suffixed** message type names on the wire. The unsuffixed forms in the
 
 ---
 
+## `asset_type` enum — v0.2.1-hackathon canonical set
+
+The v0.2 spec (Table 12) defines a broader canonical enum; for the hackathon, seeds and skills use a narrowed subset. Vendor-specific values use an `x-` prefix per SOM-039.
+
+**Case convention:**
+
+- Canonical values are `UPPER_SNAKE_CASE` (e.g. `LOWER_THIRD`, `FULL_FRAME`).
+- Vendor-specific values use `x-` + the **lowercase** original token preserving underscores (e.g. `x-graphics_pack`). Do **not** use `x-GRAPHICS_PACK` or `X-Graphics-Pack`.
+
+### Canonical values used in seeds today
+
+| Value | Notes |
+|---|---|
+| `SCRIPT` | Scripts, copy, AP wire copy |
+| `LOWER_THIRD` | Lower-third graphics |
+| `MAP` | Map graphics (static or interactive) |
+| `FULL_FRAME` | Full-frame / fullscreen graphics |
+
+### Vendor-specific values used in seeds today
+
+| Value | Notes |
+|---|---|
+| `x-graphics_pack` | Graphics package bundles |
+| `x-banner` | On-screen banners |
+| `x-package` | Edited video packages |
+
+### Full canonical set (spec Table 12)
+
+Producers MAY emit any value from the full spec enum; consumers MUST accept all of them:
+
+`VIDEO | AUDIO | GRAPHIC | STILL | CG | SCRIPT | PROMPTER | LOWER_THIRD | FULL_FRAME | MAP | SOCIAL_CARD | CUSTOM`
+
+The seed narrowing above is operational, not normative. Full reconciliation between starter seeds, dashboard rendering, and the formal spec is tracked as **SOM-048**.
+
+### What to do if you need a value not in the list
+
+1. **Check spec Table 12 first.** `PROMPTER`, `STILL`, `SOCIAL_CARD` are canonical even though not in today's seeds.
+2. **If genuinely vendor-specific,** use `x-<lowercase_token>` and note it in your vendor README. Promotion to the canonical enum is a v0.3 conversation.
+
+---
+
 ## `instance_ref` — instance scoping in the payload
 
 A story can air across many surfaces simultaneously — a linear newscast, a web live-blog, a social card. Each surface is represented by an entry in `payload.instances[]` on the inbound `story.context` message, identified by `instance_id`.
@@ -34,6 +75,8 @@ When a skill produces a warning or suggestion that applies **to a specific insta
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `instance_ref` | string | no | Value of an `instances[].instance_id` on the originating story. Omit for story-wide warnings. |
+
+> **Producer note — .NET starter:** `SkillWorker.BuildWarning()` in this branch does **not** yet emit `instance_ref`. All warnings produced by the bundled starter are story-scoped today. Vendor producers SHOULD set `instance_ref` when a warning is instance-scoped; consumers SHOULD respect it. Wiring `instance_ref` through the .NET starter's rule-engine match is a follow-up tracked against SOM-048 / SOM-049. Don't be surprised if you wire up consumption today and the starter's own warnings ignore it — that's expected.
 
 ### v0.3 target shape (Amendment A4)
 

--- a/som-hackathon-starter-dotnet/docs/message-contracts.md
+++ b/som-hackathon-starter-dotnet/docs/message-contracts.md
@@ -1,0 +1,206 @@
+# SOM Message Contracts — Skill Outputs
+
+Companion to [`som-v02-envelope.md`](./som-v02-envelope.md). That doc covers the inbound `story.context` shape; this one covers the **outbound** messages skills produce, and two cross-cutting v0.2.1 conventions:
+
+1. **`instance_ref`** — how a skill output binds to a specific story instance.
+2. **`extensions.com.{vendor}.{...}`** — how vendors add fields without changing the spec.
+
+Wire baseline: SOM v0.2 plus Amendments A1–A5 (the "v0.2.1-hackathon" label). v0.3 ratifies post-event.
+
+---
+
+## Topic reference
+
+| Topic | Producer | Consumer | Message types |
+|---|---|---|---|
+| `som.story.context` | AP / TestProducer | SkillWorker, Dashboard | `story.context` |
+| `som.skills.staging` | SkillWorker | Dashboard (Pending lane) | `skill.warning.raised`, `skill.suggestion.created` |
+| `som.skills.events` | Dashboard (approve) | Downstream | approved skill outputs |
+| `som.skills.rejected` | Dashboard (reject) | Audit | rejected skill outputs |
+| `som.skills.runs` | SkillWorker | Dashboard (audit) | `skill.run.completed` |
+
+Use the **suffixed** message type names on the wire. The unsuffixed forms in the v0.2 spec body are tracked as **SOM-049** for cleanup; the dashboard parses suffixed only.
+
+---
+
+## `instance_ref` — instance scoping in the payload
+
+A story can air across many surfaces simultaneously — a linear newscast, a web live-blog, a social card. Each surface is represented by an entry in `payload.instances[]` on the inbound `story.context` message, identified by `instance_id`.
+
+When a skill produces a warning or suggestion that applies **to a specific instance** (not the whole story), it sets a singular `instance_ref` field on its output payload, pointing back to the relevant `instance_id`.
+
+### Field — hackathon shape (v0.2.1)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `instance_ref` | string | no | Value of an `instances[].instance_id` on the originating story. Omit for story-wide warnings. |
+
+### v0.3 target shape (Amendment A4)
+
+Amendment A4 (instance-scoped skills, part of the v0.2.1-hackathon label) proposes the richer **object** form for v0.3:
+
+```yaml
+instance_ref:
+  story_id: string         # the originating story
+  instance_id: string      # matches payload.instances[].instance_id
+  instance_type: string    # e.g. "broadcast" | "social_twitter" | "article"
+```
+
+For the hackathon day, use the **string** form — `story_id` and platform metadata are already derivable from the envelope and from `payload.instances[]`. The object form is the migration target; producers and consumers SHOULD plan for it but MUST NOT block on it at the hackathon.
+
+### Why singular, not an array
+
+The shape is `instance_ref` (singular), not `instance_refs[]`. A single skill output binds to **one** instance. If the same warning applies to two instances, emit two warnings with two `warning_id`s and two `instance_ref` values. Keeping it singular keeps decision routing on the dashboard deterministic — one warning, one Pending row, one approve/reject per surface.
+
+### What's on the wire
+
+The inbound story carries the `instances[]` array; the outbound skill output carries the singular `instance_ref` referencing one of them.
+
+```json
+// payload.instances[] on story.context (inbound)
+"instances": [
+  { "instance_id": "inst-nbc-nightly-001", "platform": "linear",  "program": "NBC Nightly News" },
+  { "instance_id": "inst-nbcnews-web-001",  "platform": "web",     "program": "NBCNews.com" }
+]
+```
+
+```json
+// skill.warning.raised — hackathon minimum (itinerary §06) + instance_ref
+// On the wire, .NET starter also emits skill_version, story_id, non_overridable,
+// message_type, and timestamp. See "Spec fields" below for the full §4.4.2 shape.
+{
+  "warning_id":  "wrn-019536b1-0001",
+  "skill_id":    "nbcu/editorial-standards",
+  "severity":    "flag",
+  "rule_id":     "nbcu-style-001",
+  "affected_fields": ["headline"],
+  "detail":      "Informal term 'cops' in headline. Consider formal alternative.",
+  "blocks":      [],
+  "instance_ref": "inst-nbcnews-web-001"
+}
+```
+
+### Scoping rules
+
+| Skill intent | Set `instance_ref`? |
+|---|---|
+| Warning applies to the whole story | **No** — omit the field |
+| Warning applies only to the linear broadcast version | **Yes** — set to the linear `instance_id` |
+| Warning applies to both linear and web | Emit **two** warnings, one per `instance_ref` |
+| Warning applies to a non-existent `instance_id` | Consumer SHOULD reject — fail closed |
+
+Per itinerary §06: instance scoping rides in the payload, **not via dedicated topics**. Do not split skill warnings across `som.skills.staging.{instance}` style topics.
+
+---
+
+## `skill.warning.raised` — payload
+
+Editorial warning emitted by a skill against a story (or a specific instance).
+
+Two reference points apply:
+
+- **Skills Integration Spec §4.4.2** is the normative source for the 12-field SkillWarning payload.
+- **Itinerary §06** lists a 7-field minimum — the day-of subset producers MUST emit to satisfy hackathon validation. It is a strict subset of §4.4.2.
+
+### Spec fields (Skills Integration Spec §4.4.2)
+
+| Field | Type | §4.4.2 required | In itinerary §06 | In .NET starter |
+|---|---|:-:|:-:|:-:|
+| `warning_id` | string (UUIDv7) | MUST | ✓ | ✓ |
+| `skill_id` | string | MUST | ✓ | ✓ |
+| `skill_version` | string (semver) | MUST | — | ✓ |
+| `story_id` | string | MUST | — | ✓ |
+| `scope` | string | MUST | — | **gap** |
+| `severity` | enum `hold`\|`flag`\|`inform` | MUST | ✓ | ✓ |
+| `rule_id` | string | MUST | ✓ | ✓ |
+| `non_overridable` | boolean | MUST | — | ✓ |
+| `affected_fields` | string[] | MUST | ✓ | ✓ |
+| `detail` | string | MUST | ✓ | ✓ |
+| `blocks` | string[] | MUST | ✓ | ✓ |
+| `skill_warning_ref` | string | MUST | — | **gap** |
+
+`scope` and `skill_warning_ref` are not yet emitted by the .NET starter — tracked as follow-ups against SOM-048 / SOM-049, **out of scope for the hackathon day**.
+
+### Severity semantics (normative per §4.4.2)
+
+| Severity | Executor MUST | Subscriber MUST |
+|---|---|---|
+| `hold` | Withhold all output on affected fields until the warning is resolved | NOT use held content |
+| `flag` | Mark output as requiring review | MAY display a visual warning |
+| `inform` | Advisory only, no blocking action | No mandatory action |
+
+Dashboard treatment in the hackathon starter: `hold` lands red and cannot be approved via single click; `flag` lands yellow with standard approve/reject; `inform` lands blue and auto-clears after acknowledgement.
+
+### Envelope / routing fields emitted by the .NET starter
+
+These are not part of §4.4.2 but ride on the wire to support topic-suffix routing and audit. Consumers SHOULD ignore-if-unknown:
+
+| Field | Type | Notes |
+|---|---|---|
+| `message_type` | string | Always `"skill.warning.raised"`. The dashboard parses this for topic routing — SOM-049 tracks the spec-doc cleanup to add the `.raised` suffix in Table 4. |
+| `timestamp` | string (ISO 8601) | When the warning was raised. Envelope-level concept; likely moves to the outer envelope in v0.3. |
+
+### Optional v0.2.1 fields
+
+| Field | Type | Description |
+|---|---|---|
+| `instance_ref` | string | Bind the warning to one `instances[].instance_id` per Amendment A4. See above. |
+| `extensions` | object | Vendor-namespaced additions per A1–A5. See next section. |
+
+---
+
+## `extensions` — vendor namespace
+
+Any field outside the canonical SOM schema rides under `payload.extensions.com.{vendor}.{...}`. The namespace prevents collisions between broadcasters and keeps a clean upgrade path: anything that graduates to the spec drops its `com.{vendor}.` prefix on promotion.
+
+### Pattern
+
+```
+extensions.com.{vendor}.{field}
+```
+
+`{vendor}` is the reverse-DNS short form of the broadcaster or skill author (e.g. `nbcu`, `bbc`, `itn`). `{field}` is open.
+
+### NBCU extensions on `skill.warning.raised`
+
+Two NBCU fields exercised at the hackathon:
+
+| Path | Type | Description |
+|---|---|---|
+| `extensions.com.nbcu.citations` | array of `{ source_id, quote }` | Backing material that supports the warning — usually a quote from a rule definition or a referenced source. |
+| `extensions.com.nbcu.rationale` | string | Plain-language reason the rule fired, intended for editorial review. |
+
+### Example
+
+```json
+{
+  "warning_id": "wrn-019536b1-0001",
+  "skill_id": "nbcu/editorial-standards",
+  "severity": "flag",
+  "rule_id": "nbcu-style-001",
+  "affected_fields": ["headline"],
+  "detail": "Informal term 'cops' in headline. Consider formal alternative.",
+  "blocks": [],
+  "extensions": {
+    "com.nbcu.citations": [
+      { "source_id": "nbcu-style-guide-2026", "quote": "Use 'police' or 'officers'. Avoid 'cops' in headlines and lower thirds." }
+    ],
+    "com.nbcu.rationale": "Term 'cops' is on the NBCU Standards informal-terms list; headlines must use formal register."
+  }
+}
+```
+
+### Consumer behaviour
+
+- Consumers that don't recognise an `extensions.com.{vendor}.*` key MUST ignore it silently.
+- The dashboard's warning detail panel renders `extensions.com.nbcu.citations` and `extensions.com.nbcu.rationale` as a structured block above the raw JSON dump.
+- Promoting an extension to the spec is a v0.3 conversation — see SOM-047 / EX-8 in the UDE extensions catalogue.
+
+---
+
+## See also
+
+- [`som-v02-envelope.md`](./som-v02-envelope.md) — inbound `story.context` field reference
+- [`architecture.md`](./architecture.md) — runtime topology and dashboard data flow
+- [`skill-validation.md`](./skill-validation.md) — skill JSON schema and registry rules
+- Hackathon itinerary §06 — decided enums and shapes for the day

--- a/som-hackathon-starter-dotnet/docs/som-v02-envelope.md
+++ b/som-hackathon-starter-dotnet/docs/som-v02-envelope.md
@@ -139,7 +139,7 @@ Graphics packs, scripts, lower thirds, packages — the production assets tied t
 | Path | Type | Description |
 |------|------|-------------|
 | `assets[].asset_id` | string | Unique asset identifier |
-| `assets[].asset_type` | string | `"graphics_pack"`, `"script"`, `"lower_third"`, `"fullscreen_graphic"`, `"package"` |
+| `assets[].asset_type` | string | Canonical UPPER_SNAKE_CASE values + `x-<lowercase>` for vendor-specific. See [`message-contracts.md` — `asset_type` enum](./message-contracts.md#asset_type-enum--v021-hackathon-canonical-set) for the v0.2.1-hackathon narrowing. Full reconciliation against spec Table 12 tracked as SOM-048. |
 | `assets[].status` | string | `"READY"`, `"IN_PRODUCTION"`, `"INVALIDATED"` |
 | `assets[].invalidated_by` | string | Compliance flag_id that invalidated it |
 | `assets[].standards_clearance` | object | Optional clearance status |

--- a/som-hackathon-starter-dotnet/seed-stories/01-breaking-courthouse.json
+++ b/som-hackathon-starter-dotnet/seed-stories/01-breaking-courthouse.json
@@ -43,6 +43,21 @@
       "change_detected_at": "2026-04-01T14:44:55Z",
       "change_detected_by": "wire-ap-feed"
     },
+    "story_meaning": {
+      "who": "A US federal jury and defendant Jones, with NBC News national legal team covering the verdict.",
+      "what": "Federal jury returned a not-guilty verdict in the Jones fraud trial, contradicting widely expected conviction and invalidating pre-prepared coverage assets.",
+      "when": "Verdict delivered at 14:44 ET on 1 April 2026, during the BREAKING phase entered at 14:44:30Z.",
+      "where": "United States federal court (Jones case docket); jurisdiction US per compliance flag cf-019536a2-0001.",
+      "why": "Jury rejected the prosecution case on the merits; the outcome reversal triggers premise contradiction and an editorial legal-review gate on previously cleared sentencing assets.",
+      "how": "Reported via AP wire and court pool camera; outcome cross-checked against the pre-prepared coverage plan now blocked by legal review (gate-legal-001).",
+      "summary": "A US federal jury returned a not-guilty verdict in the Jones fraud trial, reversing the widely expected conviction. The reversal invalidated the network's pre-prepared graphics, scripts, and lower thirds, and triggered a CRITICAL premise-contradiction compliance flag plus an editorial legal-review gate blocking the existing assets ahead of NBC Nightly News.",
+      "confidence": 0.65,
+      "provenance_refs": ["src-ap-20260401-1444", "src-pool-camera-01"]
+    },
+    "government_approval": {
+      "status": "not_required",
+      "jurisdiction": "US"
+    },
     "compliance": [
       {
         "flag_id": "cf-019536a2-0001",
@@ -88,7 +103,7 @@
     "assets": [
       {
         "asset_id": "gfx-guilty-pack",
-        "asset_type": "graphics_pack",
+        "asset_type": "x-graphics_pack",
         "status": "INVALIDATED",
         "invalidated_by": "cf-019536a2-0001",
         "standards_clearance": {
@@ -99,13 +114,13 @@
       },
       {
         "asset_id": "script-summary-v2",
-        "asset_type": "script",
+        "asset_type": "SCRIPT",
         "status": "INVALIDATED",
         "invalidated_by": "cf-019536a2-0001"
       },
       {
         "asset_id": "lt-sentencing-001",
-        "asset_type": "lower_third",
+        "asset_type": "LOWER_THIRD",
         "status": "INVALIDATED",
         "invalidated_by": "cf-019536a2-0001"
       }

--- a/som-hackathon-starter-dotnet/seed-stories/02-developing-election.json
+++ b/som-hackathon-starter-dotnet/seed-stories/02-developing-election.json
@@ -36,6 +36,17 @@
       "confidence": "HIGH",
       "premise_changed": false
     },
+    "story_meaning": {
+      "who": "Virginia voters, the two gubernatorial candidates, AP Elections, the NBCU Decision Desk, and NBC and MSNBC election-night editorial leadership.",
+      "what": "The Virginia gubernatorial race remains too close to call as polls close, with 62% of precincts reporting and a margin under one percentage point.",
+      "when": "Story published 21:30 ET on 15 June 2026, with the DEVELOPING phase entered at 20:00 ET when polls began closing.",
+      "where": "Commonwealth of Virginia, with focus on outstanding counties Fairfax and Virginia Beach; coverage from NBC and MSNBC election-night control rooms.",
+      "why": "A close race coupled with embargoed exit-poll data and an active no-projection editorial hold places the desk under HIGH compliance scrutiny.",
+      "how": "Real-time results aggregated from AP Elections, the NBCU Decision Desk, and the Virginia Secretary of State, governed by the gate-projection-001 editorial hold.",
+      "summary": "The Virginia gubernatorial race is too close to call as polls close, with 62% of precincts in and the margin under one percentage point. NBC News is running the story under HIGH compliance — AP has not called the race, exit-poll data was embargoed until 19:01 ET, and an editorial hold blocks projection graphics until the Decision Desk authorises a call.",
+      "confidence": 0.80,
+      "provenance_refs": ["src-ap-election-feed", "src-nbcu-decision-desk", "src-va-sos"]
+    },
     "compliance": [
       {
         "flag_id": "cf-election-001",
@@ -99,7 +110,7 @@
     "assets": [
       {
         "asset_id": "gfx-va-results-board",
-        "asset_type": "graphics_pack",
+        "asset_type": "x-graphics_pack",
         "status": "READY",
         "standards_clearance": {
           "status": "CLEARED",
@@ -113,7 +124,7 @@
       },
       {
         "asset_id": "gfx-winner-banner",
-        "asset_type": "banner",
+        "asset_type": "x-banner",
         "status": "PREPARED",
         "standards_clearance": {
           "status": "BLOCKED",
@@ -122,7 +133,7 @@
       },
       {
         "asset_id": "lt-winner-projection",
-        "asset_type": "lower_third",
+        "asset_type": "LOWER_THIRD",
         "status": "PREPARED",
         "standards_clearance": {
           "status": "BLOCKED",
@@ -131,7 +142,7 @@
       },
       {
         "asset_id": "map-va-county-results",
-        "asset_type": "interactive_map",
+        "asset_type": "MAP",
         "status": "LIVE",
         "delivery_spec": {
           "format": "html5",

--- a/som-hackathon-starter-dotnet/seed-stories/03-informal-headline.json
+++ b/som-hackathon-starter-dotnet/seed-stories/03-informal-headline.json
@@ -36,6 +36,17 @@
       "confidence": "HIGH",
       "premise_changed": false
     },
+    "story_meaning": {
+      "who": "LAPD officers and unnamed suspects, including individuals under 18, with the KNBC Los Angeles desk handling coverage.",
+      "what": "LAPD arrested multiple individuals in a counterfeit-sneaker operation in downtown Los Angeles, with some suspects identified as minors.",
+      "when": "Story published 16:20 PT on 10 May 2026 with the DEVELOPING phase entered at 15:45 PT.",
+      "where": "Downtown Los Angeles Fashion District; jurisdiction US-CA with CA Welfare and Institutions Code 827 in effect.",
+      "why": "Minors involvement requires identity protection, and suspects not yet arraigned demand 'alleged' and 'accused' language under legal-review compliance.",
+      "how": "Reported via LAPD Public Information Office and KNBC field crew; story routed through the editorial-standards skill to catch informal headline language and protect minor identities.",
+      "summary": "LAPD arrested multiple individuals — including minors — in a counterfeit-sneaker operation in the downtown Los Angeles Fashion District. The story carries HIGH compliance under CA Welfare and Institutions Code 827 (no minor identification) and MEDIUM legal-review compliance because suspects have not yet been arraigned, requiring 'alleged' and 'accused' framing throughout.",
+      "confidence": 0.92,
+      "provenance_refs": ["src-lapd-pio", "src-knbc-crew-01"]
+    },
     "compliance": [
       {
         "flag_id": "cf-minor-001",
@@ -79,7 +90,7 @@
     "assets": [
       {
         "asset_id": "pkg-counterfeit-bust-v1",
-        "asset_type": "package",
+        "asset_type": "x-package",
         "status": "IN_PRODUCTION",
         "delivery_spec": {
           "format": "mxf",
@@ -89,12 +100,12 @@
       },
       {
         "asset_id": "lt-lapd-arrest",
-        "asset_type": "lower_third",
+        "asset_type": "LOWER_THIRD",
         "status": "READY"
       },
       {
         "asset_id": "gfx-suspect-count",
-        "asset_type": "fullscreen_graphic",
+        "asset_type": "FULL_FRAME",
         "status": "READY"
       }
     ],

--- a/som-hackathon-starter-dotnet/seed-stories/04-clean-transit.json
+++ b/som-hackathon-starter-dotnet/seed-stories/04-clean-transit.json
@@ -36,6 +36,17 @@
       "confidence": "HIGH",
       "premise_changed": false
     },
+    "story_meaning": {
+      "who": "The New York City Council, the Metropolitan Transportation Authority, and WNBC City Hall reporters.",
+      "what": "New York City Council approved a $2.1 billion public-transit expansion plan, adding three new rail lines slated for operation by 2030.",
+      "when": "Story published 11:00 ET on 12 May 2026; PUBLISHED phase entered at 10:30 ET following the council vote.",
+      "where": "New York City, with policy impact across the five boroughs and the MTA service area; jurisdiction US.",
+      "why": "A multi-billion-dollar capital programme materially changes the city's transit footprint; routine planned coverage anchored by an official vote tally.",
+      "how": "Council vote tally confirmed via the City Council Clerk, complemented by an MTA press release and WNBC City Hall Bureau crew on site.",
+      "summary": "The New York City Council voted 7-2 to approve a $2.1 billion expansion of the public-transit system, adding three new rail lines expected to be operational by 2030. The story is editorially verified with an official tally, and ran across WNBC News 4 New York at Noon, NBCNewYork.com, and NBC New York Social channels.",
+      "confidence": 0.97,
+      "provenance_refs": ["src-nyc-council-clerk", "src-mta-press", "src-wnbc-crew-03"]
+    },
     "compliance": [
       {
         "flag_id": "cf-verified-001",
@@ -77,7 +88,7 @@
     "assets": [
       {
         "asset_id": "pkg-transit-vote-v1",
-        "asset_type": "package",
+        "asset_type": "x-package",
         "status": "AIRED",
         "delivery_spec": {
           "format": "mxf",
@@ -91,7 +102,7 @@
       },
       {
         "asset_id": "gfx-transit-map-v1",
-        "asset_type": "fullscreen_graphic",
+        "asset_type": "FULL_FRAME",
         "status": "AIRED",
         "delivery_spec": {
           "format": "ndi",
@@ -101,12 +112,12 @@
       },
       {
         "asset_id": "lt-council-vote",
-        "asset_type": "lower_third",
+        "asset_type": "LOWER_THIRD",
         "status": "AIRED"
       },
       {
         "asset_id": "map-new-rail-lines",
-        "asset_type": "interactive_map",
+        "asset_type": "MAP",
         "status": "LIVE",
         "delivery_spec": {
           "format": "html5",

--- a/som-hackathon-starter-dotnet/seed-stories/05-breaking-no-compliance.json
+++ b/som-hackathon-starter-dotnet/seed-stories/05-breaking-no-compliance.json
@@ -38,6 +38,17 @@
       "confidence": "LOW",
       "premise_changed": false
     },
+    "story_meaning": {
+      "who": "Unknown individuals at a Midtown Manhattan office tower, FDNY first responders, and the NBC News breaking-news desk.",
+      "what": "An explosion was reported at a Midtown Manhattan office tower, with facts still developing and scene response active.",
+      "when": "Story published 18:02 ET on 6 May 2026; BREAKING phase entered at 18:01:30Z.",
+      "where": "Midtown Manhattan, New York City; specific tower identity pending official confirmation.",
+      "why": "Active scene with unverified casualty and cause information; story entered the bus before NBCU compliance flags or assets were attached.",
+      "how": "Initial reporting via AP wire and FDNY dispatch radio; downstream skills are expected to flag the absence of compliance metadata under the BREAKING phase.",
+      "summary": "An explosion has been reported at a Midtown Manhattan office tower, with facts still developing. The story entered the bus with no compliance flags and no prepared assets, intentionally exercising the editorial-standards skill's BREAKING-phase compliance check. Coverage is rolling across MSNBC and NBCNews.com while details from FDNY and AP are confirmed.",
+      "confidence": 0.70,
+      "provenance_refs": ["src-ap-20260506-1801", "src-fdny-radio-01"]
+    },
     "sources": [
       {
         "source_id": "src-ap-20260506-1801",

--- a/som-hackathon-starter-dotnet/skills/nbcu-editorial-standards.json
+++ b/som-hackathon-starter-dotnet/skills/nbcu-editorial-standards.json
@@ -29,7 +29,18 @@
       "default_severity": "flag",
       "output_message_type": "skill.warning.raised",
       "affected_fields": ["headline"],
-      "detail_template": "Informal term '{term}' in headline. Consider formal alternative."
+      "detail_template": "Informal term '{term}' in headline. Consider formal alternative.",
+      "citations": [
+        {
+          "source_id": "nbcu-style-guide-2026",
+          "quote": "Use 'police' or 'officers'. Avoid 'cops' in headlines and lower thirds."
+        },
+        {
+          "source_id": "nbcu-standards-handbook-3.4",
+          "quote": "Headlines must use formal register; newsroom shorthand belongs in scripts, not on air."
+        }
+      ],
+      "rationale": "Term flagged because the NBCU Standards 2026 style guide proscribes newsroom-informal language in story headlines. Editors should rewrite to a formal alternative before publish."
     },
     {
       "rule_id": "nbcu-compliance-001",
@@ -44,7 +55,14 @@
       "default_severity": "inform",
       "output_message_type": "skill.warning.raised",
       "affected_fields": ["compliance"],
-      "detail_template": "BREAKING story has no compliance flags. Verify with Standards desk."
+      "detail_template": "BREAKING story has no compliance flags. Verify with Standards desk.",
+      "citations": [
+        {
+          "source_id": "nbcu-standards-handbook-7.2",
+          "quote": "BREAKING phase stories MUST carry at least one compliance flag before air. Standards desk approval required."
+        }
+      ],
+      "rationale": "BREAKING phase without compliance flags violates NBCU Standards Handbook §7.2. Standards desk review required before any output reaches air."
     }
   ]
 }

--- a/som-hackathon-starter-dotnet/wwwroot/index.html
+++ b/som-hackathon-starter-dotnet/wwwroot/index.html
@@ -388,6 +388,31 @@ button { font: inherit; cursor: pointer; }
 
 .empty { text-align: center; padding: 24px; color: var(--text-muted); font-size: 12px; }
 .empty .icon { font-size: 28px; opacity: 0.4; margin-bottom: 4px; }
+
+/* Vendor extensions panel rendered above the raw JSON dump in the warning modal (D-002b). */
+.nbcu-ext-panel {
+  background: var(--bg-surface2); border: 1px solid var(--accent); border-radius: 10px;
+  padding: 12px 14px; margin-bottom: 14px;
+  font-family: system-ui, -apple-system, sans-serif; font-size: 12px;
+  white-space: normal; line-height: 1.5; color: var(--text);
+}
+.nbcu-ext-title {
+  font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
+  font-size: 10px; color: var(--text-muted); margin-bottom: 10px;
+}
+.nbcu-ext-row { margin-bottom: 10px; }
+.nbcu-ext-row:last-child { margin-bottom: 0; }
+.nbcu-ext-label {
+  font-weight: 600; font-size: 11px; color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.nbcu-ext-value { color: var(--text); }
+.nbcu-ext-citations { margin: 0; padding-left: 18px; }
+.nbcu-ext-citations li { margin-bottom: 4px; }
+.nbcu-ext-citations li code {
+  background: var(--chip-bg); padding: 1px 5px; border-radius: 4px;
+  font-family: "Consolas", "Fira Code", monospace; font-size: 11px;
+}
 </style>
 </head>
 <body>
@@ -939,8 +964,44 @@ function renderTimeline() {
 // ── Modal ──────────────────────────────────────────────
 function openModal(title, payload) {
   document.getElementById('modal-title').textContent = title;
-  document.getElementById('modal-body').textContent = JSON.stringify(payload, null, 2);
+  document.getElementById('modal-body').innerHTML = renderModalBody(payload);
   document.getElementById('modal-bg').classList.add('show');
+}
+
+// Render the warning/event modal body. When payload.extensions carries any
+// com.nbcu.* keys we surface them in a structured panel above the raw JSON
+// dump (D-002b). All other payloads fall through to plain JSON.
+function renderModalBody(payload) {
+  const json = escapeHtml(JSON.stringify(payload, null, 2));
+  const ext = payload?.extensions;
+  if (!ext || typeof ext !== 'object') return json;
+
+  const rationale = ext['com.nbcu.rationale'];
+  const citations = ext['com.nbcu.citations'];
+  const hasRationale = typeof rationale === 'string' && rationale.trim().length > 0;
+  const hasCitations = Array.isArray(citations) && citations.length > 0;
+  if (!hasRationale && !hasCitations) return json;
+
+  const rows = [];
+  if (hasRationale) {
+    rows.push(`<div class="nbcu-ext-row">
+      <div class="nbcu-ext-label">Rationale</div>
+      <div class="nbcu-ext-value">${escapeHtml(rationale)}</div>
+    </div>`);
+  }
+  if (hasCitations) {
+    const items = citations.map(c =>
+      `<li><code>${escapeHtml(c?.source_id ?? '?')}</code> — ${escapeHtml(c?.quote ?? '')}</li>`
+    ).join('');
+    rows.push(`<div class="nbcu-ext-row">
+      <div class="nbcu-ext-label">Citations</div>
+      <div class="nbcu-ext-value"><ul class="nbcu-ext-citations">${items}</ul></div>
+    </div>`);
+  }
+  return `<div class="nbcu-ext-panel">
+    <div class="nbcu-ext-title">NBCU extensions · extensions.com.nbcu.*</div>
+    ${rows.join('')}
+  </div>${json}`;
 }
 function closeModal() { document.getElementById('modal-bg').classList.remove('show'); }
 function closeModalIfBg(e) { if (e.target.id === 'modal-bg') closeModal(); }


### PR DESCRIPTION
Pre-flight deliverables per Hackathon Day Itinerary §04.

- D-002b: wire extensions.com.nbcu.{citations,rationale} on skill.warning.raised
- D-009: narrow asset_type to v0.2 enum + x- prefix for vendor-specific values
- D-010: add docs/message-contracts.md documenting instance_ref and extensions conventions
- D-011: story_meaning on all 5 seeds, government_approval on story 01 only

Scope discipline: broader SOM-048 envelope drift, SOM-049 spec text cleanup, and SOM-053 content body JSON shape are tracked separately for post-event v0.3 work.

Hackathon Friday 15 May at ITN — needed on main before 08:30 vendor clone.