### PR TITLE
feat(som): support Managed Kafka, Vertex AI, and GitOps flow

### DIFF
--- a/som-hackathon-starter-dotnet/.gitignore
+++ b/som-hackathon-starter-dotnet/.gitignore
@@ -27,3 +27,10 @@ claude*.md
 ## Don't ignore content directories
 !seed-stories/
 !skills/
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+*.tfvars.json

--- a/som-hackathon-starter-dotnet/DashboardService.cs
+++ b/som-hackathon-starter-dotnet/DashboardService.cs
@@ -47,7 +47,9 @@ public sealed class DashboardService : BackgroundService
             EnableIdempotence = true,
         };
         ApplyAuth(producerConfig);
-        _producer = new ProducerBuilder<string, string>(producerConfig).Build();
+        var pb = new ProducerBuilder<string, string>(producerConfig);
+        KafkaAuthHelper.AttachOAuth(pb, _options);
+        _producer = pb.Build();
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -64,8 +66,10 @@ public sealed class DashboardService : BackgroundService
             TopicMetadataRefreshIntervalMs = 3000,
         };
         ApplyAuth(consumerConfig);
+        var cb = new ConsumerBuilder<string, string>(consumerConfig);
+        KafkaAuthHelper.AttachOAuth(cb, _options);
 
-        using var consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();
+        using var consumer = cb.Build();
         consumer.Subscribe(new[]
         {
             _options.StoryContextTopic,
@@ -437,13 +441,7 @@ public sealed class DashboardService : BackgroundService
 
     private void ApplyAuth(ClientConfig config)
     {
-        if (_options.SecurityProtocol.Equals("SaslSsl", StringComparison.OrdinalIgnoreCase))
-        {
-            config.SecurityProtocol = SecurityProtocol.SaslSsl;
-            config.SaslMechanism = SaslMechanism.Plain;
-            config.SaslUsername = _options.SaslUsername;
-            config.SaslPassword = _options.SaslPassword;
-        }
+        KafkaAuthHelper.Configure(config, _options);
     }
 
     public override void Dispose()

--- a/som-hackathon-starter-dotnet/KafkaAuthHelper.cs
+++ b/som-hackathon-starter-dotnet/KafkaAuthHelper.cs
@@ -1,0 +1,79 @@
+using Confluent.Kafka;
+using System;
+
+namespace SomSkillWorker;
+
+internal static class KafkaAuthHelper
+{
+    public static void Configure(ClientConfig config, KafkaOptions options)
+    {
+        if (Enum.TryParse<SecurityProtocol>(options.SecurityProtocol, true, out var sp))
+        {
+            config.SecurityProtocol = sp;
+        }
+
+        if (Enum.TryParse<SaslMechanism>(options.SaslMechanism, true, out var sm))
+        {
+            config.SaslMechanism = sm;
+        }
+
+        if (options.SecurityProtocol.Equals("SaslSsl", StringComparison.OrdinalIgnoreCase))
+        {
+            if (options.SaslMechanism.Equals("Plain", StringComparison.OrdinalIgnoreCase))
+            {
+                config.SaslUsername = Environment.GetEnvironmentVariable("WorkerSaEmail") ?? options.SaslUsername;
+                
+                // Fetch short-lived access token as password
+                var credential = Google.Apis.Auth.OAuth2.GoogleCredential.GetApplicationDefaultAsync().GetAwaiter().GetResult();
+                if (credential.IsCreateScopedRequired)
+                {
+                    credential = credential.CreateScoped(new[] { "https://www.googleapis.com/auth/cloud-platform" });
+                }
+                var tokenAccess = (Google.Apis.Auth.OAuth2.ITokenAccess)credential;
+                config.SaslPassword = tokenAccess.GetAccessTokenForRequestAsync().GetAwaiter().GetResult();
+            }
+            else
+            {
+                config.SaslUsername = options.SaslUsername;
+                config.SaslPassword = options.SaslPassword;
+            }
+        }
+    }
+
+    public static void AttachOAuth<TKey, TValue>(ProducerBuilder<TKey, TValue> builder, KafkaOptions options)
+    {
+        if (options.SaslMechanism.Equals("OAuthBearer", StringComparison.OrdinalIgnoreCase))
+        {
+            builder.SetOAuthBearerTokenRefreshHandler(OauthTokenRefreshCallback);
+        }
+    }
+
+    public static void AttachOAuth<TKey, TValue>(ConsumerBuilder<TKey, TValue> builder, KafkaOptions options)
+    {
+        if (options.SaslMechanism.Equals("OAuthBearer", StringComparison.OrdinalIgnoreCase))
+        {
+            builder.SetOAuthBearerTokenRefreshHandler(OauthTokenRefreshCallback);
+        }
+    }
+
+    private static void OauthTokenRefreshCallback(IClient client, string config)
+    {
+        try
+        {
+            var credential = Google.Apis.Auth.OAuth2.GoogleCredential.GetApplicationDefaultAsync().GetAwaiter().GetResult();
+            if (credential.IsCreateScopedRequired)
+            {
+                credential = credential.CreateScoped(new[] { "https://www.googleapis.com/auth/cloud-platform" });
+            }
+            var tokenAccess = (Google.Apis.Auth.OAuth2.ITokenAccess)credential;
+            var token = tokenAccess.GetAccessTokenForRequestAsync().GetAwaiter().GetResult();
+            long lifetimeMs = new DateTimeOffset(DateTime.UtcNow.AddMinutes(50)).ToUnixTimeMilliseconds();
+            var principal = Environment.GetEnvironmentVariable("WorkerSaEmail") ?? "som-worker";
+            client.OAuthBearerSetToken(token, lifetimeMs, principal);
+        }
+        catch (Exception ex)
+        {
+            client.OAuthBearerSetTokenFailure(ex.ToString());
+        }
+    }
+}

--- a/som-hackathon-starter-dotnet/README.md
+++ b/som-hackathon-starter-dotnet/README.md
@@ -305,6 +305,38 @@ The dashboard is served on port `5050` both inside the container (via `ASPNETCOR
 
 Update the `Dockerfile` base image tags from `10.0-preview` to `10.0` once .NET 10 reaches GA.
 
+## Deployment to Google Cloud
+
+This repository includes a `terraform` directory for deploying the application to Google Cloud using Managed Service for Apache Kafka and Cloud Run.
+
+Due to circular dependencies between Artifact Registry, Cloud Build, and Cloud Run, follow these steps for the initial deployment:
+
+1.  **Initialize Terraform**:
+    ```bash
+    cd terraform
+    terraform init
+    ```
+2.  **Enable Artifact Registry API**:
+    ```bash
+    terraform apply -target=google_project_service.artifactregistry
+    ```
+3.  **Create the Repository**:
+    ```bash
+    terraform apply -target=google_artifact_registry_repository.repo
+    ```
+4.  **Build and Push Image**:
+    Use the provided `cloudbuild.yaml` to build and push the image. You may need to update the substitutions in `cloudbuild.yaml` to match your region and repository name.
+    ```bash
+    cd ..
+    gcloud builds submit --config cloudbuild.yaml .
+    ```
+5.  **Complete Deployment**:
+    Run a full apply to create Cloud Run and Kafka resources.
+    ```bash
+    cd terraform
+    terraform apply
+    ```
+
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE).

--- a/som-hackathon-starter-dotnet/SkillReviewer.cs
+++ b/som-hackathon-starter-dotnet/SkillReviewer.cs
@@ -58,7 +58,8 @@ public static class SkillReviewerFactory
         if (!string.IsNullOrWhiteSpace(anthropicKey))
             return new AnthropicSkillReviewer(http, logFactory.CreateLogger<AnthropicSkillReviewer>(), anthropicKey);
 
-        return new NoopSkillReviewer();
+        // Default to Vertex AI using ADC
+        return new VertexAiSkillReviewer(http, logFactory.CreateLogger<VertexAiSkillReviewer>());
     }
 }
 
@@ -166,6 +167,108 @@ internal static class SkillReviewPrompt
         if (firstBrace >= 0 && lastBrace > firstBrace)
             return trimmed.Substring(firstBrace, lastBrace - firstBrace + 1);
         return trimmed;
+    }
+
+    public static string ExtractModelText(string responseJson)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(responseJson);
+            var candidates = doc.RootElement.GetProperty("candidates");
+            var parts = candidates[0].GetProperty("content").GetProperty("parts");
+            return parts[0].GetProperty("text").GetString() ?? "";
+        }
+        catch { return responseJson; }
+    }
+
+    public static string Truncate(string s, int max) => s.Length <= max ? s : s[..max] + "…";
+}
+
+// ─── Vertex AI (IAM/ADC) ─────────────────────────────────────────────────────
+
+public sealed class VertexAiSkillReviewer : ISkillReviewer
+{
+    private readonly IHttpClientFactory _http;
+    private readonly ILogger<VertexAiSkillReviewer> _logger;
+    private readonly string _projectId;
+    private readonly string _region;
+    private readonly string _model;
+
+    public string ProviderName => $"google/vertex/{_model}";
+    public bool Available => true;
+
+    public VertexAiSkillReviewer(IHttpClientFactory http, ILogger<VertexAiSkillReviewer> logger)
+    {
+        _http = http;
+        _logger = logger;
+        _projectId = Environment.GetEnvironmentVariable("PROJECT_ID") ?? "ibc-smart-stories";
+        _region = Environment.GetEnvironmentVariable("LOCATION") ?? "europe-west1";
+        _model = Environment.GetEnvironmentVariable("GEMINI_MODEL") ?? "gemini-2.0-flash";
+    }
+
+    public async Task<SkillReviewResult> ReviewAsync(
+        SkillDefinition skill,
+        IReadOnlyCollection<JsonNode> sampleStories,
+        DryRunResult? dryRun,
+        CancellationToken ct)
+    {
+        var prompt = SkillReviewPrompt.Build(skill, sampleStories, dryRun);
+        var host = _region.Equals("global", StringComparison.OrdinalIgnoreCase)
+            ? "aiplatform.googleapis.com"
+            : $"{_region}-aiplatform.googleapis.com";
+        var url = $"https://{host}/v1/projects/{_projectId}/locations/{_region}/publishers/google/models/{_model}:generateContent";
+
+        var body = new JsonObject
+        {
+            ["contents"] = new JsonArray(new JsonObject
+            {
+                ["role"] = "user",
+                ["parts"] = new JsonArray(new JsonObject { ["text"] = prompt }),
+            }),
+            ["generationConfig"] = new JsonObject
+            {
+                ["temperature"] = 0.3,
+                ["responseMimeType"] = "application/json",
+            },
+        };
+
+        try
+        {
+            var credential = await Google.Apis.Auth.OAuth2.GoogleCredential.GetApplicationDefaultAsync();
+            if (credential.IsCreateScopedRequired)
+            {
+                credential = credential.CreateScoped(new[] { "https://www.googleapis.com/auth/cloud-platform" });
+            }
+            var tokenAccess = (Google.Apis.Auth.OAuth2.ITokenAccess)credential;
+            var token = await tokenAccess.GetAccessTokenForRequestAsync();
+            _logger.LogInformation("Fetched access token for Vertex AI. Length: {Length}", token?.Length ?? 0);
+
+            using var http = _http.CreateClient();
+            http.Timeout = TimeSpan.FromSeconds(45);
+            using var req = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
+            };
+            req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+            using var resp = await http.SendAsync(req, ct);
+            var text = await resp.Content.ReadAsStringAsync(ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Vertex AI returned {Status}: {Body}", resp.StatusCode, text);
+                return new SkillReviewResult(true, ProviderName, null, Array.Empty<SkillReviewFinding>(),
+                    $"Vertex AI API {(int)resp.StatusCode}: {SkillReviewPrompt.Truncate(text, 400)}", text);
+            }
+
+            var modelText = SkillReviewPrompt.ExtractModelText(text);
+            return SkillReviewPrompt.ParseModelReply(modelText, ProviderName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Vertex AI review failed");
+            return new SkillReviewResult(true, ProviderName, null, Array.Empty<SkillReviewFinding>(),
+                $"Vertex AI call failed: {ex.Message}", null);
+        }
     }
 }
 

--- a/som-hackathon-starter-dotnet/SkillWorker.cs
+++ b/som-hackathon-starter-dotnet/SkillWorker.cs
@@ -41,8 +41,13 @@ public class SkillWorker : BackgroundService
         var producerConfig = BuildProducerConfig();
         var consumerConfig = BuildConsumerConfig();
 
-        _producer = new ProducerBuilder<string, string>(producerConfig).Build();
-        _consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();
+        var pb = new ProducerBuilder<string, string>(producerConfig);
+        var cb = new ConsumerBuilder<string, string>(consumerConfig);
+        KafkaAuthHelper.AttachOAuth(pb, _options);
+        KafkaAuthHelper.AttachOAuth(cb, _options);
+
+        _producer = pb.Build();
+        _consumer = cb.Build();
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -229,13 +234,7 @@ public class SkillWorker : BackgroundService
 
     private void ApplyAuth(ClientConfig config)
     {
-        if (_options.SecurityProtocol.Equals("SaslSsl", StringComparison.OrdinalIgnoreCase))
-        {
-            config.SecurityProtocol = SecurityProtocol.SaslSsl;
-            config.SaslMechanism = SaslMechanism.Plain;
-            config.SaslUsername = _options.SaslUsername;
-            config.SaslPassword = _options.SaslPassword;
-        }
+        KafkaAuthHelper.Configure(config, _options);
     }
 
     public override void Dispose()

--- a/som-hackathon-starter-dotnet/SomSkillWorker.csproj
+++ b/som-hackathon-starter-dotnet/SomSkillWorker.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.68.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="seed-stories\**\*.json">

--- a/som-hackathon-starter-dotnet/TestProducer.cs
+++ b/som-hackathon-starter-dotnet/TestProducer.cs
@@ -83,15 +83,11 @@ public static class TestProducer
             Acks = Acks.Leader,
         };
 
-        if (options.SecurityProtocol.Equals("SaslSsl", StringComparison.OrdinalIgnoreCase))
-        {
-            config.SecurityProtocol = SecurityProtocol.SaslSsl;
-            config.SaslMechanism = SaslMechanism.Plain;
-            config.SaslUsername = options.SaslUsername;
-            config.SaslPassword = options.SaslPassword;
-        }
+        KafkaAuthHelper.Configure(config, options);
 
-        using var producer = new ProducerBuilder<string, string>(config).Build();
+        var pb = new ProducerBuilder<string, string>(config);
+        KafkaAuthHelper.AttachOAuth(pb, options);
+        using var producer = pb.Build();
 
         // If no scenario specified, publish all seed stories
         var scenarios = scenario is null

--- a/som-hackathon-starter-dotnet/cloudbuild.yaml
+++ b/som-hackathon-starter-dotnet/cloudbuild.yaml
@@ -1,0 +1,28 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', '$_LOCATION-docker.pkg.dev/$PROJECT_ID/$_REPOSITORY/som-skill-worker:latest', '.']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', '$_LOCATION-docker.pkg.dev/$PROJECT_ID/$_REPOSITORY/som-skill-worker:latest']
+
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args:
+  - 'run'
+  - 'services'
+  - 'update'
+  - 'som-skill-worker'
+  - '--region=$_LOCATION'
+  - '--image=$_LOCATION-docker.pkg.dev/$PROJECT_ID/$_REPOSITORY/som-skill-worker:latest'
+
+images:
+- '$_LOCATION-docker.pkg.dev/$PROJECT_ID/$_REPOSITORY/som-skill-worker:latest'
+
+substitutions:
+  _LOCATION: europe-west1
+  _REPOSITORY: som-repo
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+serviceAccount: 'projects/$PROJECT_ID/serviceAccounts/som-cloudbuild-sa@$PROJECT_ID.iam.gserviceaccount.com'

--- a/som-hackathon-starter-dotnet/terraform/.terraform.lock.hcl
+++ b/som-hackathon-starter-dotnet/terraform/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.32.0"
+  hashes = [
+    "h1:izatO4h5Akqy4v1bha4w9FQmmCueZYwN3+hr9n5ZBW8=",
+    "zh:091afeeeb58035f26ebaec34755a15d56e3229c4ce6db2745c52ba2593204a30",
+    "zh:15d6a375c49d023dd21e612610b12bf79fbc6459bc5ad64b989d2180e9931f7d",
+    "zh:2c70ee949b01c0c7925618e36417ac5b9c1de91c66bb0bd956b2b2bd1d38a2b6",
+    "zh:2e531cf6f3af847104df65675ebd9c9a7450ba91d8d21ff6ed04eeab6a5684e2",
+    "zh:42fece780ef909136213762731c945d59c58dbaf92f64a46989102da9ebfa998",
+    "zh:9008b13bec8c588ef41ec813c3d67d26acb22ada241d9dd9ed408687607726cc",
+    "zh:a62e09bd551de8ea74b68c1eb44f9d7d0dc56957811915d46ec0a28254a30e0b",
+    "zh:ad3d4419561d19e88b72ad4bedbbc73ee77f20acb594261be8f716bf1a89f947",
+    "zh:af0c23df89e5fb815751c64c9a438527d6e0609df52fa7e281dbd90aa238270b",
+    "zh:b4d1157559d04792441550ae79f13d16bd7cc3f80a9616cd9ef3f83466564ce4",
+    "zh:db32528838dc9641981769012bdabf21e658756f1581ccbcd239aab0eb4aed11",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/som-hackathon-starter-dotnet/terraform/backend.tf
+++ b/som-hackathon-starter-dotnet/terraform/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket  = "ibc-smart-stories-initial-deploy-state"
+    prefix  = "terraform/state"
+  }
+}

--- a/som-hackathon-starter-dotnet/terraform/main.tf
+++ b/som-hackathon-starter-dotnet/terraform/main.tf
@@ -1,0 +1,285 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Enable APIs
+resource "google_project_service" "compute" {
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "run" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "vpcaccess" {
+  service            = "vpcaccess.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "managedkafka" {
+  service            = "managedkafka.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "artifactregistry" {
+  service            = "artifactregistry.googleapis.com"
+  disable_on_destroy = false
+}
+
+
+# Networking
+resource "google_compute_network" "vpc" {
+  name                    = "som-vpc"
+  auto_create_subnetworks = false
+  depends_on              = [google_project_service.compute]
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "som-subnet"
+  ip_cidr_range = "10.0.0.0/24"
+  network       = google_compute_network.vpc.id
+  region        = var.region
+}
+
+# Serverless VPC Access Connector
+resource "google_vpc_access_connector" "connector" {
+  name          = "som-vpc-connector"
+  region        = var.region
+  ip_cidr_range = "10.8.0.0/28"
+  network       = google_compute_network.vpc.name
+  min_instances = 2
+  max_instances = 3
+  depends_on    = [google_project_service.vpcaccess]
+}
+
+# Managed Kafka Cluster
+resource "google_managed_kafka_cluster" "kafka" {
+  cluster_id = var.cluster_name
+  location   = var.region
+
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472 # 3 GiB
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = google_compute_subnetwork.subnet.id
+      }
+    }
+  }
+
+  rebalance_config {
+    mode = "NO_REBALANCE"
+  }
+
+  depends_on = [google_project_service.managedkafka]
+}
+
+# Kafka Topics
+resource "google_managed_kafka_topic" "story_context" {
+  topic_id           = "som.story.context"
+  cluster            = google_managed_kafka_cluster.kafka.cluster_id
+  location           = var.region
+  partition_count    = 3
+  replication_factor = 3
+}
+
+resource "google_managed_kafka_topic" "skills_staging" {
+  topic_id           = "som.skills.staging"
+  cluster            = google_managed_kafka_cluster.kafka.cluster_id
+  location           = var.region
+  partition_count    = 3
+  replication_factor = 3
+}
+
+resource "google_managed_kafka_topic" "skills_events" {
+  topic_id           = "som.skills.events"
+  cluster            = google_managed_kafka_cluster.kafka.cluster_id
+  location           = var.region
+  partition_count    = 3
+  replication_factor = 3
+}
+
+resource "google_managed_kafka_topic" "skills_rejected" {
+  topic_id           = "som.skills.rejected"
+  cluster            = google_managed_kafka_cluster.kafka.cluster_id
+  location           = var.region
+  partition_count    = 3
+  replication_factor = 3
+}
+
+resource "google_managed_kafka_topic" "skills_runs" {
+  topic_id           = "som.skills.runs"
+  cluster            = google_managed_kafka_cluster.kafka.cluster_id
+  location           = var.region
+  partition_count    = 3
+  replication_factor = 3
+}
+# Artifact Registry
+resource "google_artifact_registry_repository" "repo" {
+  location      = var.region
+  repository_id = var.repository_name
+  description   = "Docker repository for SOM Skill Worker"
+  format        = "DOCKER"
+}
+# Service Account for Cloud Build
+resource "google_service_account" "cloudbuild_sa" {
+  account_id   = "som-cloudbuild-sa"
+  display_name = "Cloud Build Service Account for SOM"
+}
+
+# IAM role for Artifact Registry Writer
+resource "google_project_iam_member" "cloudbuild_repo_writer" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.cloudbuild_sa.email}"
+}
+
+# IAM role for Storage Object Viewer on source bucket
+resource "google_storage_bucket_iam_member" "cloudbuild_source_reader" {
+  bucket = var.cloudbuild_bucket
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.cloudbuild_sa.email}"
+}
+
+# IAM role for Log Writer for Cloud Build SA
+resource "google_project_iam_member" "cloudbuild_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloudbuild_sa.email}"
+}
+
+
+# Grant Cloud Build SA permission to deploy to Cloud Run
+resource "google_project_iam_member" "cloudbuild_run_developer" {
+  project = var.project_id
+  role    = "roles/run.developer"
+  member  = "serviceAccount:${google_service_account.cloudbuild_sa.email}"
+}
+
+# Grant Cloud Build SA permission to act as the worker SA
+resource "google_project_iam_member" "cloudbuild_sa_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.cloudbuild_sa.email}"
+}
+
+# Service Account for Cloud Run Worker
+resource "google_service_account" "worker_sa" {
+  account_id   = "som-worker-sa"
+  display_name = "Runtime Service Account for Cloud Run Worker"
+}
+
+# Grant Managed Kafka Client access to the Worker SA
+resource "google_project_iam_member" "worker_kafka_client" {
+  project = var.project_id
+  role    = "roles/managedkafka.client"
+  member  = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+# Grant Log Writer access to the Worker SA
+resource "google_project_iam_member" "worker_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+# Grant Vertex AI User access to the Worker SA
+resource "google_project_iam_member" "worker_vertex_user" {
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+
+
+# Cloud Run Service
+resource "google_cloud_run_v2_service" "app" {
+  name     = "som-skill-worker"
+  location = var.region
+  deletion_protection = false
+
+  template {
+    service_account = google_service_account.worker_sa.email
+
+    containers {
+      image = var.image_url
+
+      ports {
+        container_port = 5050
+      }
+
+      env {
+        name  = "ASPNETCORE_ENVIRONMENT"
+        value = "Production"
+      }
+
+      env {
+        name  = "Kafka__BootstrapServers"
+        value = var.kafka_bootstrap_servers
+      }
+
+      # Managed Service for Apache Kafka mandates TLS encryption on all broker listeners.
+      # Authentication is enforced via OAUTHBEARER using standard Application Default Credentials.
+      env {
+        name  = "Kafka__SecurityProtocol"
+        value = "SaslSsl"
+      }
+
+      env {
+        name  = "Kafka__SaslMechanism"
+        value = "Plain"
+      }
+
+      env {
+        name  = "Kafka__SaslUsername"
+        value = google_service_account.worker_sa.email
+      }
+
+      env {
+        name  = "GEMINI_MODEL"
+        value = "gemini-3-flash-preview"
+      }
+
+      env {
+        name  = "LOCATION"
+        value = "global"
+      }
+
+
+
+
+    }
+
+    vpc_access {
+      connector = google_vpc_access_connector.connector.id
+      egress    = "ALL_TRAFFIC"
+    }
+
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 5
+    }
+  }
+
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  depends_on = [google_project_service.run]
+}
+
+# TODO(security): Implement Identity-Aware Proxy (IAP) to restrict public access once developer identities are collected.
+resource "google_cloud_run_v2_service_iam_member" "public_access" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.app.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/som-hackathon-starter-dotnet/terraform/outputs.tf
+++ b/som-hackathon-starter-dotnet/terraform/outputs.tf
@@ -1,0 +1,6 @@
+output "cloud_run_url" {
+  description = "The URL of the Cloud Run service"
+  value       = google_cloud_run_v2_service.app.uri
+}
+
+

--- a/som-hackathon-starter-dotnet/terraform/terraform.tfvars.example
+++ b/som-hackathon-starter-dotnet/terraform/terraform.tfvars.example
@@ -1,0 +1,7 @@
+project_id   = "your-project-id"
+region       = "us-central1"
+cluster_name = "som-kafka-cluster"
+image_url    = "us-central1-docker.pkg.dev/your-project-id/som-repo/som-skill-worker:latest"
+repository_name = "som-repo"
+kafka_bootstrap_servers = "host:port"
+cloudbuild_bucket = "som-infra-examples_cloudbuild"

--- a/som-hackathon-starter-dotnet/terraform/variables.tf
+++ b/som-hackathon-starter-dotnet/terraform/variables.tf
@@ -1,0 +1,44 @@
+variable "project_id" {
+  description = "The Google Cloud project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "The region to deploy resources to"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  description = "The name of the Managed Kafka cluster"
+  type        = string
+  default     = "som-kafka-cluster"
+}
+
+variable "image_url" {
+  description = "The Docker image URL for the application"
+  type        = string
+}
+
+variable "repository_name" {
+  description = "The name of the Artifact Registry repository"
+  type        = string
+  default     = "som-repo"
+}
+
+variable "kafka_bootstrap_servers" {
+  description = "The bootstrap servers for the Managed Kafka cluster"
+  type        = string
+  default     = ""
+}
+
+variable "cloudbuild_bucket" {
+  description = "The name of the Cloud Build source bucket"
+  type        = string
+}
+
+variable "github_owner" {
+  description = "The GitHub owner of the repository"
+  type        = string
+  default     = "jgrayston"
+}


### PR DESCRIPTION
- Centralize Kafka authentication in KafkaAuthHelper.cs supporting SASL/PLAIN with short-lived access tokens via ADC.

- Update SkillWorker, DashboardService, and TestProducer to use KafkaAuthHelper.

- Add VertexAiSkillReviewer to use Vertex AI endpoints with ADC tokens for AI review feature, complying with org policy disallowing API keys.

- Fix URL construction for global region in Vertex AI calls.

- Add deploy step to cloudbuild.yaml for auto-deployment to Cloud Run.

- Provision dedicated runtime service account and grant required IAM roles in Terraform.

