### PR TITLE
feat(terraform): add Tailscale subnet router for remote Kafka access

### DIFF
--- a/som-hackathon-starter-dotnet/README.md
+++ b/som-hackathon-starter-dotnet/README.md
@@ -331,11 +331,55 @@ Due to circular dependencies between Artifact Registry, Cloud Build, and Cloud R
     gcloud builds submit --config cloudbuild.yaml .
     ```
 5.  **Complete Deployment**:
-    Run a full apply to create Cloud Run and Kafka resources.
+    Run a full apply to create Cloud Run, Kafka resources, and the Tailscale Subnet Router.
     ```bash
     cd terraform
     terraform apply
     ```
+
+### Connecting Remotely via Tailscale (for Developers)
+
+To subscribe to Managed Kafka topics or run a local skill worker against the cloud cluster, developers need network-level access to the GCP VPC. We use Tailscale as a subnet router.
+
+#### 1. Administrator Setup (Once after deployment)
+If you did not provide a `tailscale_auth_key` in `terraform.tfvars`, the subnet router VM was provisioned but not authenticated.
+1. SSH into the router VM using the command from Terraform outputs:
+   ```bash
+   gcloud compute ssh som-tailscale-router --tunnel-through-iap --project <project_id> --zone <zone>
+   ```
+2. Run `sudo tailscale up --advertise-routes=10.0.0.0/24` and follow the printed URL to authenticate.
+3. In your **Tailscale Admin Console**:
+   - Locate the `som-tailscale-router` device.
+   - Go to **Route settings** (under the meatball menu next to the device).
+   - Enable the advertised route `10.0.0.0/24`.
+   - Optionally disable key expiry on this device so it doesn't disconnect.
+
+#### 2. Developer Laptop Configuration
+Each developer who needs to connect from their local machine must do the following:
+
+1. **Install Tailscale**: Download and install Tailscale from [tailscale.com](https://tailscale.com).
+2. **Join the Tailnet**: Log in to the same Tailscale network used by the project.
+3. **Accept Subnet Routes**:
+   - **macOS / Windows**: Open Tailscale settings and ensure **Use Subnet Routes** (or "Accept Subnet Routes") is toggled ON.
+   - **Linux**: Run `sudo tailscale up --accept-routes`.
+4. **Authenticate with GCP (ADC)**:
+   Ensure you have the GCP SDK installed, then run:
+   ```bash
+   gcloud auth login
+   gcloud auth application-default login
+   ```
+   *Note: Your GCP user account must be granted the `roles/managedkafka.client` role in the GCP project to authenticate with Kafka.*
+5. **Run the Application**:
+   Configure the application to use the GCP Managed Kafka bootstrap server (find the actual URL in your terraform outputs or ask the administrator):
+   ```bash
+   export Kafka__BootstrapServers="bootstrap.som-kafka-cluster.[...].managedkafka.[...].cloud.goog:9092"
+   export Kafka__SecurityProtocol="SaslSsl"
+   export Kafka__SaslMechanism="Plain"
+   export Kafka__SaslUsername="YOUR_GCP_EMAIL@example.com" # must match the ADC login identity
+   
+   dotnet run
+   ```
+
 
 ## License
 

--- a/som-hackathon-starter-dotnet/terraform/main.tf
+++ b/som-hackathon-starter-dotnet/terraform/main.tf
@@ -275,6 +275,70 @@ resource "google_cloud_run_v2_service" "app" {
   depends_on = [google_project_service.run]
 }
 
+# Firewall rule to allow IAP SSH to instances
+resource "google_compute_firewall" "allow_iap_ssh" {
+  name    = "som-allow-iap-ssh"
+  network = google_compute_network.vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"] # Google Cloud Identity-Aware Proxy IP range
+  target_tags   = ["tailscale-router"]
+}
+
+# Tailscale Subnet Router VM
+resource "google_compute_instance" "tailscale_router" {
+  name         = "som-tailscale-router"
+  machine_type = "t2d-standard-1" # Switch to Tau T2D AMD series due to E2/N1 resource exhaustion
+  zone         = "${var.region}-b"
+
+
+
+
+
+
+
+
+  tags = ["tailscale-router"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnet.id
+    
+    # We give it a public IP so it can download Tailscale packages from the internet.
+    # It does not accept inbound traffic except via IAP (handled by firewall above).
+    access_config {}
+  }
+
+  # Enable IP forwarding for routing subnet traffic
+  can_ip_forward = true
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    # Enable IP forwarding in OS
+    echo 'net.ipv4.ip_forward = 1' | tee -a /etc/sysctl.d/99-tailscale.conf
+    echo 'net.ipv6.conf.all.forwarding = 1' | tee -a /etc/sysctl.d/99-tailscale.conf
+    sysctl -p /etc/sysctl.d/99-tailscale.conf
+
+    # Install Tailscale
+    curl -fsSL https://tailscale.com/install.sh | sh
+
+    # If auth key is provided, authenticate automatically
+    if [ -n "${var.tailscale_auth_key}" ]; then
+      tailscale up --authkey="${var.tailscale_auth_key}" --advertise-routes="10.0.0.0/24"
+    fi
+  EOT
+}
+
+
 # TODO(security): Implement Identity-Aware Proxy (IAP) to restrict public access once developer identities are collected.
 resource "google_cloud_run_v2_service_iam_member" "public_access" {
   project  = var.project_id

--- a/som-hackathon-starter-dotnet/terraform/outputs.tf
+++ b/som-hackathon-starter-dotnet/terraform/outputs.tf
@@ -3,4 +3,15 @@ output "cloud_run_url" {
   value       = google_cloud_run_v2_service.app.uri
 }
 
+output "tailscale_router_instance_name" {
+  description = "The name of the Tailscale Subnet Router VM"
+  value       = google_compute_instance.tailscale_router.name
+}
+
+output "tailscale_ssh_command" {
+  description = "Gcloud command to SSH into the Tailscale Subnet Router VM via IAP tunnel"
+  value       = "gcloud compute ssh ${google_compute_instance.tailscale_router.name} --tunnel-through-iap --project ${var.project_id} --zone ${google_compute_instance.tailscale_router.zone}"
+}
+
+
 

--- a/som-hackathon-starter-dotnet/terraform/variables.tf
+++ b/som-hackathon-starter-dotnet/terraform/variables.tf
@@ -37,6 +37,14 @@ variable "cloudbuild_bucket" {
   type        = string
 }
 
+variable "tailscale_auth_key" {
+  description = "Optional Tailscale auth key to auto-authenticate the subnet router. Generate from Tailscale admin panel."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+
 variable "github_owner" {
   description = "The GitHub owner of the repository"
   type        = string


### PR DESCRIPTION
- Add som-tailscale-router VM instance in europe-west1-b (t2d-standard-1).

- Add firewall rule som-allow-iap-ssh to allow SSH via IAP.

- Add tailscale_auth_key variable to support auto-authentication.

- Add outputs for VM name and gcloud IAP SSH tunnel command.

- Update README.md with instructions for developers to connect via Tailscale and authenticate GCP Managed Kafka using ADC.