### PR TITLE
fix(cloudbuild): set working directory to dotnet project directory fo…

### DIFF
--- a/som-hackathon-starter-dotnet/cloudbuild.yaml
+++ b/som-hackathon-starter-dotnet/cloudbuild.yaml
@@ -1,6 +1,8 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
+  dir: 'som-hackathon-starter-dotnet'
   args: ['build', '-t', '$_LOCATION-docker.pkg.dev/$PROJECT_ID/$_REPOSITORY/som-skill-worker:latest', '.']
+
 
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', '$_LOCATION-docker.pkg.dev/$PROJECT_ID/$_REPOSITORY/som-skill-worker:latest']


### PR DESCRIPTION
…r build step

This ensures that the build context matches the dotnet project folder structure, resolving the missing Dockerfile and project reference errors when triggered from the root of the repository.