### PR TITLE
Fix reverse_order query parameter for TAMS flow segments

### DIFF
--- a/tams/app/main.py
+++ b/tams/app/main.py
@@ -298,7 +298,7 @@ def create_flow_segments(flowId: str, segments: Union[FlowSegmentPost, List[Flow
     return {"message": "Segments created successfully"}
 
 @app.get("/flows/{flowId}/segments", response_model=List[FlowSegmentPost], response_model_exclude_none=True)
-def get_flow_segments(flowId: str, timerange: Optional[str] = None, limit: Optional[int] = 100, presigned: bool = False):
+def get_flow_segments(flowId: str, timerange: Optional[str] = None, limit: Optional[int] = 100, presigned: bool = False, reverse_order: bool = False):
     query = db.collection("segments").where("flow_id", "==", flowId)
     
     segments = []
@@ -322,6 +322,11 @@ def get_flow_segments(flowId: str, timerange: Optional[str] = None, limit: Optio
         docs = query.limit(limit).get()
         for doc in docs:
             segments.append(doc.to_dict())
+
+    if reverse_order:
+        segments.sort(key=lambda seg: seg.get("timerange_start", 0), reverse=True)
+    else:
+        segments.sort(key=lambda seg: seg.get("timerange_start", 0))
             
     segments = segments[:limit]
     

--- a/tams/tests/test_main.py
+++ b/tams/tests/test_main.py
@@ -407,6 +407,40 @@ def test_get_flow_segments_basic(client, mock_db):
     assert len(response.json()) == 2
 
 
+def test_get_flow_segments_reverse_order(client, mock_db):
+    from mediatimestamp.immutable import TimeRange
+    t1 = TimeRange.from_str("100_200")
+    t2 = TimeRange.from_str("300_400")
+    t3 = TimeRange.from_str("500_600")
+
+    mock_db.collection("segments").document("s1").set({
+        "object_id": "obj-1",
+        "flow_id": "flow-1",
+        "timerange": "100_200",
+        "timerange_start": t1.start.to_nanosec(),
+        "timerange_end": t1.end.to_nanosec()
+    })
+    mock_db.collection("segments").document("s2").set({
+        "object_id": "obj-2",
+        "flow_id": "flow-1",
+        "timerange": "300_400",
+        "timerange_start": t2.start.to_nanosec(),
+        "timerange_end": t2.end.to_nanosec()
+    })
+    mock_db.collection("segments").document("s3").set({
+        "object_id": "obj-3",
+        "flow_id": "flow-1",
+        "timerange": "500_600",
+        "timerange_start": t3.start.to_nanosec(),
+        "timerange_end": t3.end.to_nanosec()
+    })
+
+    response = client.get("/flows/flow-1/segments?reverse_order=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert [segment["object_id"] for segment in data] == ["obj-3", "obj-2", "obj-1"]
+
+
 def test_get_flow_segments_filter_and_invalid_timerange(client, mock_db):
     # Seed segments (with standard timestamps, e.g. 100s -> 100_000_000_000 ns)
     from mediatimestamp.immutable import TimeRange


### PR DESCRIPTION
## Summary

This PR implements support for the `reverse_order` query parameter for the TAMS Flow Segments endpoint.

## Changes

- Implemented handling of the `reverse_order` query parameter.
- Segments are now returned in reverse chronological order when `reverse_order=true`.
- Preserved the existing forward ordering when `reverse_order` is not specified or is set to `false`.

## Testing

Tested the following scenarios:

- ✅ `GET /flows/{flow_id}/segments?reverse_order=true`
  - Returns segments in reverse chronological order.

- ✅ `GET /flows/{flow_id}/segments`
  - Returns segments in the default forward order.

- ✅ Verified behavior with and without the `timerange` query parameter.

## Issue

Fixes #315