### PR TITLE
SomHackathon: #317 review follow-ups (Bucket B)

### DIFF
--- a/som-hackathon-starter-dotnet/DashboardService.cs
+++ b/som-hackathon-starter-dotnet/DashboardService.cs
@@ -45,6 +45,9 @@ public sealed class DashboardService : BackgroundService
             BootstrapServers = _options.BootstrapServers,
             Acks = Acks.All,
             EnableIdempotence = true,
+            // Bounded: with librdkafka's 5-min default, a broker outage hangs an
+            // approve/reject click for minutes before failing.
+            MessageTimeoutMs = 10000,
         };
         ApplyAuth(producerConfig);
         var pb = new ProducerBuilder<string, string>(producerConfig);
@@ -108,7 +111,8 @@ public sealed class DashboardService : BackgroundService
                 // can republish it without round-tripping through Kafka or the seed files.
                 if (result.Topic == _options.StoryContextTopic)
                 {
-                    var sid = (node["payload"]?["story_id"] ?? node["story_id"])?.GetValue<string>();
+                    var sidNode = node["payload"]?["story_id"] ?? node["story_id"];
+                    var sid = sidNode is JsonValue sv && sv.TryGetValue<string>(out var s) ? s : null;
                     if (sid is not null) _stories[sid] = node;
                 }
 
@@ -237,13 +241,22 @@ public sealed class DashboardService : BackgroundService
 
         if (decision.Equals("approve", StringComparison.OrdinalIgnoreCase))
         {
-            // Annotate and republish to the production bus.
+            // Annotate and republish to the production bus. If the produce fails, put the
+            // pending item BACK — a broker blip must not silently discard a staged warning.
             var enriched = pending.Output.DeepClone();
             enriched["approved_by"] = reviewer ?? "dashboard-user";
             enriched["approved_at"] = DateTimeOffset.UtcNow.ToString("o");
 
-            await _producer.ProduceAsync(_options.SkillEventsTopic,
-                new Message<string, string> { Key = key, Value = enriched.ToJsonString() }, ct);
+            try
+            {
+                await _producer.ProduceAsync(_options.SkillEventsTopic,
+                    new Message<string, string> { Key = key, Value = enriched.ToJsonString() }, ct);
+            }
+            catch
+            {
+                _pending[outputId] = pending;
+                throw;
+            }
 
             await BroadcastAsync(new
             {
@@ -263,8 +276,16 @@ public sealed class DashboardService : BackgroundService
             enriched["rejected_by"] = reviewer ?? "dashboard-user";
             enriched["rejected_at"] = DateTimeOffset.UtcNow.ToString("o");
 
-            await _producer.ProduceAsync(_options.SkillRejectedTopic,
-                new Message<string, string> { Key = key, Value = enriched.ToJsonString() }, ct);
+            try
+            {
+                await _producer.ProduceAsync(_options.SkillRejectedTopic,
+                    new Message<string, string> { Key = key, Value = enriched.ToJsonString() }, ct);
+            }
+            catch
+            {
+                _pending[outputId] = pending;
+                throw;
+            }
 
             await BroadcastAsync(new
             {

--- a/som-hackathon-starter-dotnet/MediaCoordinatorService.cs
+++ b/som-hackathon-starter-dotnet/MediaCoordinatorService.cs
@@ -157,8 +157,8 @@ public sealed class MediaCoordinatorService : BackgroundService
         // Thread the arrival's correlation onto anything we produce in reaction to it, and
         // record the arrival as the cause (causation_id) — correlation MUST survive end to end.
         var envelope = node as JsonObject;
-        var correlationId = envelope?["correlation_id"]?.GetValue<string>();
-        var causationId = envelope?["message_id"]?.GetValue<string>();
+        var correlationId = envelope?["correlation_id"] is JsonValue crv && crv.TryGetValue<string>(out var cr) ? cr : null;
+        var causationId = envelope?["message_id"] is JsonValue miv && miv.TryGetValue<string>(out var mi) ? mi : null;
 
         var storyId = _dashboard.FindStoryIdByAssetId(assetId);
 

--- a/som-hackathon-starter-dotnet/SimulatorService.cs
+++ b/som-hackathon-starter-dotnet/SimulatorService.cs
@@ -33,6 +33,9 @@ public sealed class SimulatorService : BackgroundService
     private CancellationTokenSource? _scenarioCts;
     private string? _runningScenarioId;
     private DateTimeOffset? _runningStartedAt;
+    // Per-run token: restarting the SAME scenario id must not let the old (cancelled)
+    // run's cleanup null out the new run's status.
+    private Guid _runToken;
 
     private bool _autoEnabled;
     private int _autoIntervalSeconds = 20;
@@ -125,8 +128,9 @@ public sealed class SimulatorService : BackgroundService
         _scenarioCts = new CancellationTokenSource();
         _runningScenarioId = scenario.Id;
         _runningStartedAt = DateTimeOffset.UtcNow;
+        var token = _runToken = Guid.NewGuid();
 
-        _ = Task.Run(() => RunScenarioLoopAsync(scenario, _scenarioCts.Token));
+        _ = Task.Run(() => RunScenarioLoopAsync(scenario, token, _scenarioCts.Token));
         return true;
     }
 
@@ -138,7 +142,7 @@ public sealed class SimulatorService : BackgroundService
         return Task.CompletedTask;
     }
 
-    private async Task RunScenarioLoopAsync(SimulationScenario scenario, CancellationToken ct)
+    private async Task RunScenarioLoopAsync(SimulationScenario scenario, Guid runToken, CancellationToken ct)
     {
         _logger.LogInformation("▶ Running scenario {Id} ({StepCount} steps)", scenario.Id, scenario.Actions.Length);
         var startedAt = DateTimeOffset.UtcNow;
@@ -164,7 +168,7 @@ public sealed class SimulatorService : BackgroundService
         }
         finally
         {
-            if (_runningScenarioId == scenario.Id)
+            if (_runToken == runToken)
             {
                 _runningScenarioId = null;
                 _runningStartedAt = null;

--- a/som-hackathon-starter-dotnet/docs/SOM-v0.3.1-distribution-contracts.md
+++ b/som-hackathon-starter-dotnet/docs/SOM-v0.3.1-distribution-contracts.md
@@ -85,6 +85,12 @@ Announces that media has **arrived in (or is growing inside) a TAMS/MAM store**.
 "extensions": { "com.ibc-poc.capture_complete": true }
 ```
 
+**After the announcement — fetching the bytes.** The delivery event says the essence is reachable; it carries no credentials and no bytes. Retrieval is a store concern below the SOM boundary: authenticate to the TAMS store and read via its API — for this PoC's GCP deployment see [`tams/DEVELOPER_AUTH_GUIDE.md`](../../tams/DEVELOPER_AUTH_GUIDE.md) at the repo root. SOM never proxies media.
+
+**Cold consumers — resolving `asset_id` with no cached story.** The event deliberately carries no `story_id`; you resolve `asset_id → Asset → Story` from `story.context`. A consumer that joins late has three options, in preference order: (1) replay `som.story.context` from the earliest retained offset and keep the latest version per `story_id` (what this starter's dashboard does); (2) hold the arrival briefly — stories republish in full on every change, so the next version is rarely far away (the reference coordinator re-checks for ~1s); (3) after a bounded wait, treat it as unmatched (the coordinator then records the `WITHHELD` audit). There is no story query API in v0.3.1 — resolution is stream-first by design.
+
+**Who emits on the shared dev broker.** The shared dev server runs the **broker only** — no vendor code, no mock MAM. `MockMamService` runs inside whichever participant runs the starter (locally, pointed at the shared broker). A consumer-only partner who sees no delivery traffic isn't broken — nobody is emitting; run the starter yourself or agree on who drives the scenario.
+
 **Not the right carrier for a public livestream URL you want to transcribe** — that is a *live ingest source*, not arrived TAMS media. See [Vendor extensions](#vendor-extensions--adding-fields-without-breaking-the-spec) for how to carry an ingest URL today.
 
 ---

--- a/som-hackathon-starter-dotnet/docs/som-v02-envelope.md
+++ b/som-hackathon-starter-dotnet/docs/som-v02-envelope.md
@@ -228,7 +228,7 @@ The rule engine accesses fields via dot-notation paths relative to the payload r
 | `priority.level` | `payload.priority.level` (string) |
 | `premise.premise_changed` | `payload.premise.premise_changed` (boolean) |
 
-Array fields (`compliance`, `sources`, `assets`, etc.) are checked for presence/absence as a whole. The built-in rule engine does not currently iterate into array elements — if you need per-element logic (e.g. "any compliance flag with type X"), implement a custom rule type in `RuleEngine.cs`.
+Array fields (`compliance`, `assets`, etc.) are checked for presence/absence as a whole by most rule types. The `field_changed` rule type additionally supports one `[]` array wildcard (e.g. `assets[].acquisition_state`) — elements are matched across story versions by `asset_id`/`source_id`/`flag_id`/`id`. For other per-element logic (e.g. "any compliance flag with type X"), implement a custom rule type in `RuleEngine.cs`.
 
 ## Seed stories
 

--- a/som-hackathon-starter-dotnet/schema/validate.py
+++ b/som-hackathon-starter-dotnet/schema/validate.py
@@ -68,11 +68,19 @@ def check_message(path, *, released_story=False):
     return errs(sch, d) if sch else [type("E", (), {"message": "no schema matched"})()]
 
 def main():
+    # (glob_dir, min_expected) — a deleted fixture directory must FAIL, not read as "all valid".
+    groups = [
+        (glob.glob(os.path.join(ROOT, "seed-stories", "*.json")), {}, 5, "seed-stories"),
+        (glob.glob(os.path.join(SCH, "examples", "*.json")), {"released_story": True}, 1, "schema/examples"),
+        (glob.glob(os.path.join(P, "examples", "*.json")), {}, 5, "v0.3.1-proposed/examples"),
+        (glob.glob(os.path.join(ROOT, "mos-bridge", "samples", "*.expected.json")), {}, 1, "mos-bridge fixtures"),
+    ]
     targets = []
-    targets += [(f, {}) for f in glob.glob(os.path.join(ROOT, "seed-stories", "*.json"))]
-    targets += [(f, {"released_story": True}) for f in glob.glob(os.path.join(SCH, "examples", "*.json"))]
-    targets += [(f, {}) for f in glob.glob(os.path.join(P, "examples", "*.json"))]
-    targets += [(f, {}) for f in glob.glob(os.path.join(ROOT, "mos-bridge", "samples", "*.expected.json"))]
+    for files, opts, minimum, label in groups:
+        if len(files) < minimum:
+            print(f"FATAL: expected at least {minimum} fixture(s) in {label}, found {len(files)} — glob broken or files deleted")
+            sys.exit(1)
+        targets += [(f, opts) for f in files]
 
     bad = 0
     for path, opts in sorted(targets):


### PR DESCRIPTION
Bucket B from Nigel's #317 review — the agreed non-blocking follow-ups, split out so #317 stays merge-ready. **Stacked on #317**: this diff shows #317's commits until it merges; the Bucket-B delta is the single commit `cb2e3ad`.

## Code

- **DecideAsync durability (review B1)**: a broker blip during approve/reject no longer silently discards the staged warning — the produce failure puts the pending item back (mirrors `RepublishAsync`'s produce-then-clear). The Dashboard producer gains `MessageTimeoutMs=10s`, so the click fails in seconds instead of hanging ~5 minutes; this also bounds the coordinator's CAPTURED story-flip, which routes through the same producer (review B10).
- **Tolerant envelope reads (B2)**: coordinator `correlation_id`/`message_id` and the dashboard's `story_id` cache read now use the `is JsonValue && TryGetValue` idiom — a present-but-non-string value degrades instead of throwing.
- **Simulator same-id restart (B9)**: per-run token stops the old cancelled run's cleanup from nulling the new run's status.
- **validate.py fixture guard (B5)**: minimum-count assertion per glob group — a deleted fixture directory now fails loudly instead of reading as "OK — all valid".

## Docs

- **Delivery section, three partner paths (B6–B8)**: how to auth/fetch bytes after the announcement (links `tams/DEVELOPER_AUTH_GUIDE.md`; SOM never proxies media); how a cold consumer resolves `asset_id` with no cached story (replay / brief hold / bounded-wait WITHHELD — stream-first by design); who runs the emitter against the shared dev broker (broker-only server — the mock MAM runs in whoever runs the starter).
- **Envelope doc array claim (B4)**: corrected — `field_changed`'s `[]` wildcard does iterate arrays.

## Already landed in #317 (not here)

- B3 (schema README stale notes + system-audit rows) — folded into #317's DECISION commit, same files.
- The "14/14 → 15/15" PR-description half of B5.

## Verification

`dotnet build` 0 warnings; `python3 schema/validate.py` 15/15 with the new guard active.
