### PR TITLE
SomHackathon: GET /api/stories story directory — read-only live-set projection

### DIFF
--- a/som-hackathon-starter-dotnet/DashboardService.cs
+++ b/som-hackathon-starter-dotnet/DashboardService.cs
@@ -113,7 +113,19 @@ public sealed class DashboardService : BackgroundService
                 {
                     var sidNode = node["payload"]?["story_id"] ?? node["story_id"];
                     var sid = sidNode is JsonValue sv && sv.TryGetValue<string>(out var s) ? s : null;
-                    if (sid is not null) _stories[sid] = node;
+                    if (sid is not null)
+                    {
+                        _stories[sid] = node;
+                        // Warn ONCE, at ingest, when a story can never appear in the
+                        // /api/stories directory — the read path skips silently (it runs
+                        // per poll), so this line is the only log evidence explaining why.
+                        var st = (node["payload"] ?? node) is JsonObject po
+                            && po["story_type"] is JsonValue stv && stv.TryGetValue<string>(out var stVal) ? stVal : null;
+                        if (st is not ("ACTIVE" or "PLANNED" or "KILLED" or "SPIKED" or "ARCHIVED" or "ORPHAN"))
+                            _logger.LogWarning(
+                                "Story {StoryId} cached with missing/unknown story_type ({StoryType}) — it will not appear in the /api/stories directory",
+                                sid, st ?? "∅");
+                    }
                 }
 
                 // For staged outputs, hold them in the pending queue so the UI can approve/reject.
@@ -506,6 +518,57 @@ public sealed class DashboardService : BackgroundService
             payload = p.Output,
         })
         .ToArray();
+
+    /// <summary>
+    /// The story-directory projection: a thin, SOM-shaped listing of the live story set
+    /// materialised from the bus. This is a read-only CACHE of the bus, never a second
+    /// home for the truth — and serving it is a role any participant could fill, not a
+    /// privilege of this process. Live set = story_type ACTIVE/PLANNED only: closed
+    /// types (KILLED/SPIKED/ARCHIVED) are over, and ORPHAN is v0.3.2 preview scaffolding
+    /// that must not leak into a directory partners browse.
+    /// </summary>
+    public IReadOnlyCollection<JsonObject> SnapshotStories()
+    {
+        var rows = new List<(DateTimeOffset UpdatedAt, JsonObject Row)>();
+        foreach (var (storyId, node) in _stories)
+        {
+            // Tolerant reads: one malformed story must not poison the directory. The
+            // typed guards cover wrong-typed fields; the try covers what guards cannot —
+            // JsonObject materializes nested objects lazily and THROWS on duplicate JSON
+            // keys, and nothing touches a cached story's lifecycle internals before here,
+            // so without it one hand-crafted envelope 500s the endpoint for everyone.
+            try
+            {
+                if ((node["payload"] ?? node) is not JsonObject p) continue;
+                if (p["story_type"] is not JsonValue tv || !tv.TryGetValue<string>(out var storyType)) continue;
+                if (storyType is not ("ACTIVE" or "PLANNED")) continue;
+
+                var updated = p["updated_at"] is JsonValue uv && uv.TryGetValue<string>(out var u) ? u : null;
+                var row = new JsonObject
+                {
+                    ["story_id"] = storyId,
+                    ["slug"] = p["slug"] is JsonValue sv && sv.TryGetValue<string>(out var slug) ? slug : null,
+                    ["headline"] = p["headline"] is JsonValue hv && hv.TryGetValue<string>(out var headline) ? headline : null,
+                    ["story_type"] = storyType,
+                    ["updated_at"] = updated,
+                };
+                // lifecycle iff the story carries one (ACTIVE-only, decision #19) — the
+                // projection mirrors the schema rule rather than flattening it away.
+                if (p["lifecycle"] is JsonObject lc && lc["phase"] is JsonValue pv && pv.TryGetValue<string>(out var phase))
+                    row["lifecycle"] = new JsonObject { ["phase"] = phase };
+
+                // The bus carries mixed timestamp shapes ("…Z" seeds vs "o"-format
+                // republishes), so ordinal string order can invert near-ties — parse.
+                rows.Add((DateTimeOffset.TryParse(updated, out var ts) ? ts : DateTimeOffset.MinValue, row));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Story directory: cached story {StoryId} is unreadable — omitted from /api/stories", storyId);
+            }
+        }
+        return rows.OrderByDescending(r => r.UpdatedAt).Select(r => r.Row).ToArray();
+    }
 
     // ─── Helpers ────────────────────────────────────────────────────────────
 

--- a/som-hackathon-starter-dotnet/Program.cs
+++ b/som-hackathon-starter-dotnet/Program.cs
@@ -212,6 +212,12 @@ app.MapPost("/api/decision/{id}", async (
         : Results.BadRequest(new { error = result.Status });
 });
 
+// ── Story directory (read-only) ────────────────────────
+// The ingest-journey entry point: list the live story set so a joining participant can
+// find a story_id to reference. A cache of the bus, never the truth — the bus stays the
+// source of record, and any participant could serve this same directory role.
+app.MapGet("/api/stories", (DashboardService dash) => Results.Ok(dash.SnapshotStories()));
+
 app.MapPost("/api/stories/{storyId}/rerun", async (
     string storyId, DashboardService dash, CancellationToken ct) =>
 {

--- a/som-hackathon-starter-dotnet/README.md
+++ b/som-hackathon-starter-dotnet/README.md
@@ -275,6 +275,7 @@ The skill registry header in the dashboard shows a status badge: `🤖 google/ge
 | `GET` | `/api/pending` | Staged outputs awaiting approve/reject |
 | `POST` | `/api/decision/{id}` | Body: `{decision:"approve"|"reject", reviewer:"..."}` |
 | `POST` | `/api/publish/{scenario}` | Publish one seed story to the bus |
+| `GET` | `/api/stories` | Story directory: live stories (ACTIVE/PLANNED) as a thin projection — a read-only cache of the bus, not a source of truth |
 | `POST` | `/api/stories/{id}/rerun` | Republish cached story → skill re-runs |
 | `POST` | `/api/stories/{id}/advance-phase` | Mutate `lifecycle.phase` to next canonical, republish |
 | `POST` | `/api/stories/{id}/add-compliance` | Body: `{type, severity, detail}`, append flag and republish |


### PR DESCRIPTION
## What

The story-directory read side committed to the WG thread with Morag (18 Jul): `GET /api/stories` lists the live story set as a thin, SOM-shaped projection so a joining participant (ingest journey) can find a `story_id` to reference. One endpoint + one snapshot method + one README row.

Per the pattern note's rules, the directory is:
- **Read-only** — it serves the dashboard's existing latest-per-`story_id` bus cache; a cache of the bus, never a second home for the truth.
- **A role, not a system** — any participant could serve the same projection; nothing here is privileged.
- **The live set only** — `story_type` `ACTIVE`/`PLANNED`. Closed types (`KILLED`/`SPIKED`/`ARCHIVED`) and v0.3.2 `ORPHAN` previews never enter the directory.
- **Thin** — `story_id`, `slug`, `headline`, `story_type`, `lifecycle.phase` (present iff carried, mirroring the ACTIVE-only schema rule), `updated_at`; newest first.

The pattern itself is non-normative (recommended-not-required, no wire/schema change) — this is the reference implementation demonstrating it.

## Stacking

Based on `som-v031-followups`. **Merge order: #317 → #321 → this.** Until those land, this PR's diff shows their commits too; the actual delta here is the single commit `20644a1`.

## Verification

- `dotnet build` — 0 warnings, 0 errors.
- Live-verified twice against a real bus on an isolated instance (unique consumer groups): materialised 6 stories with correct shape, live-set filtering, and newest-first order across both timestamp formats on the bus (`…Z` seeds and `"o"`-format republishes).
- Three-agent review pass (code review, silent-failure hunt, test analysis) ran before opening; all findings addressed in this commit:
  - **Duplicate-JSON-key poisoning (critical):** `JsonObject` materializes nested objects lazily and throws on duplicate keys, and nothing touches a cached story's `lifecycle` internals before this read — one hand-crafted envelope could persistently 500 the endpoint. Fixed with per-row tolerance: the poisoned story is logged (with `story_id`) and omitted; everyone else's directory keeps working.
  - **Invisible exclusions:** a story that can never appear in the directory (missing/unknown `story_type`, e.g. wrong-case `Active`) now logs one warning at ingest — the read path stays silent because it runs per poll.
  - **Sort correctness:** ordering uses parsed `DateTimeOffset` (tolerant fallback), not ordinal string compare, so mixed timestamp shapes can't invert near-ties.

## Test spec (for the tracked C# test project)

Ranked by regression risk, from the review pass: (1) filter allowlist — one story of each `story_type`, assert exactly ACTIVE+PLANNED return; (2) envelope vs bare-payload unwrap produce identical rows; (3) malformed-story tolerance — mixed good/bad cache entries, good rows survive, no throw (including the duplicate-key case); (4) `lifecycle` present iff carried; (5) newest-first with null `updated_at` last.
