### PR TITLE
SomHackathon: dashboard decisions write som.system.audit (CLEARED/WITHHELD)

### DIFF
--- a/som-hackathon-starter-dotnet/DashboardService.cs
+++ b/som-hackathon-starter-dotnet/DashboardService.cs
@@ -270,6 +270,11 @@ public sealed class DashboardService : BackgroundService
                 throw;
             }
 
+            // Post-commit work: the decision is already on the bus, so the audit must not
+            // ride the request token — a client disconnect mid-produce would leave the act
+            // unaudited AND unlogged. The producer's 10s MessageTimeoutMs still bounds it.
+            await EmitDecisionAuditAsync(pending, "CLEARED", reviewer ?? "dashboard-user", CancellationToken.None);
+
             await BroadcastAsync(new
             {
                 type = "decision",
@@ -298,6 +303,9 @@ public sealed class DashboardService : BackgroundService
                 _pending[outputId] = pending;
                 throw;
             }
+
+            // Post-commit: detached from the request token (see the approve branch).
+            await EmitDecisionAuditAsync(pending, "WITHHELD", reviewer ?? "dashboard-user", CancellationToken.None);
 
             await BroadcastAsync(new
             {
@@ -591,6 +599,98 @@ public sealed class DashboardService : BackgroundService
     {
         _producer.Dispose();
         base.Dispose();
+    }
+
+    /// <summary>
+    /// Record a human gate decision on som.system.audit — the governance-grade act.
+    /// approve → CLEARED; reject → WITHHELD (terminal for this output instance; a
+    /// re-run creates a new output). Mirrors MediaCoordinatorService's audit envelope:
+    /// same correlation_id as the staged output, causation_id = the staged message_id.
+    /// Audit failure is logged loudly but never undoes the decision — the republish
+    /// has already happened; the record must not be able to veto the act.
+    /// </summary>
+    private async Task EmitDecisionAuditAsync(
+        PendingOutput pending, string action, string reviewer, CancellationToken ct)
+    {
+        try
+        {
+            var envelope = pending.Output;
+            var payload = envelope["payload"] ?? envelope;
+            var (targetKind, targetId) = ResolveAuditTarget(payload);
+            var skillId = payload?["skill_id"] is JsonValue skv && skv.TryGetValue<string>(out var sk) ? sk : "unknown-skill";
+            var storyId = payload?["story_id"] is JsonValue sidv && sidv.TryGetValue<string>(out var sid) ? sid : null;
+            var now = DateTimeOffset.UtcNow;
+
+            var auditPayload = new JsonObject
+            {
+                ["message_type"] = "system.audit",
+                ["audit_id"] = Guid.NewGuid().ToString(),
+                ["action"] = action,
+                ["target"] = new JsonObject { ["kind"] = targetKind, ["id"] = targetId },
+                ["actor"] = new JsonObject { ["actor_id"] = reviewer, ["actor_type"] = "user" },
+                ["reason"] = $"Dashboard gate decision '{action}' on staged output '{pending.OutputId}' from skill '{skillId}'"
+                    + (storyId is null ? "" : $" (story '{storyId}')"),
+                ["recorded_at"] = now.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'"),
+            };
+
+            var auditEnvelope = new JsonObject
+            {
+                ["som_version"] = "0.2.0",
+                ["message_id"] = Guid.NewGuid().ToString(),
+                // Thread the staged output's lifecycle: same correlation, caused by the staged message.
+                ["correlation_id"] = envelope["correlation_id"] is JsonValue cv && cv.TryGetValue<string>(out var corr) ? corr : Guid.NewGuid().ToString(),
+                ["message_type"] = "system.audit",
+                ["timestamp"] = now.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'"),
+                ["originating_system"] = new JsonObject
+                {
+                    ["system_id"] = "ibc-poc-dashboard",
+                    ["system_type"] = "editorial_dashboard",
+                    ["system_name"] = "Staging Dashboard (human approval gate)",
+                    ["vendor"] = "ibc-poc",
+                    ["version"] = "0.1",
+                },
+                ["topic"] = _options.AuditTopic,
+                ["payload"] = auditPayload,
+            };
+            if (envelope["message_id"] is JsonValue mv && mv.TryGetValue<string>(out var causation))
+                auditEnvelope["causation_id"] = causation;
+
+            await _producer.ProduceAsync(_options.AuditTopic,
+                new Message<string, string> { Key = pending.StoryKey ?? pending.OutputId, Value = auditEnvelope.ToJsonString() }, ct);
+            _logger.LogInformation(
+                "Dashboard: decision audit {Action} for output {OutputId} recorded on {Topic} (reviewer {Reviewer})",
+                action, pending.OutputId, _options.AuditTopic, reviewer);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Same posture as MediaCoordinator's WITHHELD path: if the audit can't be
+            // recorded, say exactly that — the decision stands but is unrecorded.
+            _logger.LogError(ex,
+                "Dashboard: decision audit {Action} for output {OutputId} could NOT be confirmed on {Topic} — the clearance may exist only in topic annotations",
+                action, pending.OutputId, _options.AuditTopic);
+        }
+    }
+
+    /// <summary>
+    /// Best-effort mapping of a staged output onto the locked audit target set
+    /// (LINK | ASSET | TELLING). Warnings/suggestions scope to their firing level:
+    /// "link:{id}" → LINK; else the first affected_fields path "assets.{id}.…" → ASSET;
+    /// else ASSET keyed by story (demo-grade fallback, still schema-valid).
+    /// </summary>
+    private static (string Kind, string Id) ResolveAuditTarget(JsonNode? payload)
+    {
+        var scope = payload?["scope"] is JsonValue scv && scv.TryGetValue<string>(out var sc) ? sc : null;
+        if (scope is not null && scope.StartsWith("link:", StringComparison.Ordinal))
+            return ("LINK", scope["link:".Length..]);
+
+        if (payload?["affected_fields"] is JsonArray fields && fields.Count > 0)
+        {
+            var parts = fields[0] is JsonValue fv && fv.TryGetValue<string>(out var f) ? f.Split('.') : null;
+            if (parts is { Length: >= 2 } && parts[0] == "assets")
+                return ("ASSET", parts[1]);
+        }
+
+        return ("ASSET", payload?["story_id"] is JsonValue sv2 && sv2.TryGetValue<string>(out var s2) ? s2 : "unknown");
     }
 
     private sealed record PendingOutput(


### PR DESCRIPTION
## What

The dashboard's human approve/reject gate now writes the governance trail. Every decision records a `som.system.audit` envelope: **approve → `CLEARED`**, **reject → `WITHHELD`** (terminal for this output instance — a re-run creates a new output). The actor is the reviewer (`actor_type: "user"`) — the human counterpart of the media coordinator's `"system"` actor. Until now the clearance decision existed only as `approved_by`/`rejected_by` annotations on the events/rejected topics; the audit trail is where "who cleared what" belongs.

One file: `DashboardService.cs` (+100). v0.3.1-locked machinery only — the audit event and action set are ratified; nothing proposed rides in.

## Design guarantees

- **The record can never veto the act.** The audit is attempted only after the decision produce succeeded, its failure is logged loudly and swallowed, and it is detached from the request token — a client disconnect mid-produce cannot leave the act unaudited *and* unlogged (bounded by the producer's 10s `MessageTimeoutMs`).
- **Traceable end to end**: `correlation_id` echoes the staged output's; `causation_id` = the staged output's `message_id`; the `reason` carries output id, skill id, and story id.
- **Tolerant reads throughout** — a wrong-typed field on a hand-crafted vendor envelope degrades tier-by-tier (link scope → asset from `affected_fields` → story-keyed fallback), never drops the record wholesale.
- A produce failure logs "could NOT be *confirmed*" — a delivery timeout doesn't prove absence, and the log line is honest about that.
- No audit on the `invalid_decision` path — no act occurred.

## Verification

- `dotnet build` — 0 warnings, 0 errors. Snyk clean.
- Live loop, twice (isolated instances, unique consumer groups): seed → staged warnings → approve + reject → **CLEARED and WITHHELD envelopes captured off the bus**, `causation_id` cross-checked against the staging topic's `message_id`s (exact match), both payloads validate against `som-v0.3.1-system-audit.schema.json`; `schema/validate.py` suite still fully green.
- Regression: approve/reject still republish with annotations; a broker failure on the decision produce still restores the pending item before any audit is attempted.
- Three-agent review pass ran before opening; all findings fixed and re-verified live: request-abort cancellation could previously skip audit + error log + broadcast after the decision committed (now detached from the request token); throwing JSON reads could drop a whole record on one malformed field (now tolerant); failure log overclaimed certainty; story id added to `reason`.

## Test spec (for the tracked C# test project)

Ranked: (1) **audit failure never blocks or corrupts the decision** — inject an audit-topic-only producer failure, assert the decision result, pending removal, and error log all hold (highest-value guard: a regression here corrupts gate state, not just a record); (2) `ResolveAuditTarget` mapping table (link scope → LINK; `assets.{id}` affected_fields → ASSET; precedence; fallbacks); (3) envelope threading — correlation carried, causation present iff the staged envelope had a `message_id`, `som_version` pinned; (4) no audit on `invalid_decision`.
