### PR TITLE
SomHackathon: audit follow-ups from #323 review — real targets, honest labels, docs

### DIFF
--- a/som-hackathon-starter-dotnet/DashboardService.cs
+++ b/som-hackathon-starter-dotnet/DashboardService.cs
@@ -270,11 +270,6 @@ public sealed class DashboardService : BackgroundService
                 throw;
             }
 
-            // Post-commit work: the decision is already on the bus, so the audit must not
-            // ride the request token — a client disconnect mid-produce would leave the act
-            // unaudited AND unlogged. The producer's 10s MessageTimeoutMs still bounds it.
-            await EmitDecisionAuditAsync(pending, "CLEARED", reviewer ?? "dashboard-user", CancellationToken.None);
-
             await BroadcastAsync(new
             {
                 type = "decision",
@@ -283,6 +278,12 @@ public sealed class DashboardService : BackgroundService
                 reviewer = reviewer ?? "dashboard-user",
                 at = DateTimeOffset.UtcNow,
             }, ct);
+
+            // Post-commit, post-broadcast: the audit rides neither the request token nor
+            // the UI's critical path — on a degraded broker the operator's confirmation
+            // must not wait up to 10s behind the audit produce. Failure inside is logged,
+            // never thrown.
+            await EmitDecisionAuditAsync(pending, "CLEARED", reviewer ?? "dashboard-user");
 
             return new DecisionResult(true, "approved", _options.SkillEventsTopic);
         }
@@ -304,9 +305,6 @@ public sealed class DashboardService : BackgroundService
                 throw;
             }
 
-            // Post-commit: detached from the request token (see the approve branch).
-            await EmitDecisionAuditAsync(pending, "WITHHELD", reviewer ?? "dashboard-user", CancellationToken.None);
-
             await BroadcastAsync(new
             {
                 type = "decision",
@@ -315,6 +313,9 @@ public sealed class DashboardService : BackgroundService
                 reviewer = reviewer ?? "dashboard-user",
                 at = DateTimeOffset.UtcNow,
             }, ct);
+
+            // Post-commit, post-broadcast (see the approve branch).
+            await EmitDecisionAuditAsync(pending, "WITHHELD", reviewer ?? "dashboard-user");
 
             return new DecisionResult(true, "rejected", _options.SkillRejectedTopic);
         }
@@ -609,14 +610,13 @@ public sealed class DashboardService : BackgroundService
     /// Audit failure is logged loudly but never undoes the decision — the republish
     /// has already happened; the record must not be able to veto the act.
     /// </summary>
-    private async Task EmitDecisionAuditAsync(
-        PendingOutput pending, string action, string reviewer, CancellationToken ct)
+    private async Task EmitDecisionAuditAsync(PendingOutput pending, string action, string reviewer)
     {
         try
         {
-            var envelope = pending.Output;
-            var payload = envelope["payload"] ?? envelope;
-            var (targetKind, targetId) = ResolveAuditTarget(payload);
+            var envelope = pending.Output as JsonObject;
+            var payload = envelope?["payload"] as JsonObject ?? envelope;
+            var (targetKind, targetId, storyFallback) = ResolveAuditTarget(payload);
             var skillId = payload?["skill_id"] is JsonValue skv && skv.TryGetValue<string>(out var sk) ? sk : "unknown-skill";
             var storyId = payload?["story_id"] is JsonValue sidv && sidv.TryGetValue<string>(out var sid) ? sid : null;
             var now = DateTimeOffset.UtcNow;
@@ -629,7 +629,10 @@ public sealed class DashboardService : BackgroundService
                 ["target"] = new JsonObject { ["kind"] = targetKind, ["id"] = targetId },
                 ["actor"] = new JsonObject { ["actor_id"] = reviewer, ["actor_type"] = "user" },
                 ["reason"] = $"Dashboard gate decision '{action}' on staged output '{pending.OutputId}' from skill '{skillId}'"
-                    + (storyId is null ? "" : $" (story '{storyId}')"),
+                    + (storyId is null ? "" : $" (story '{storyId}')")
+                    + (storyFallback
+                        ? " — story-scoped: target.id is the STORY key, not an asset id (no STORY target kind in v0.3.1; v0.3.2 candidate)"
+                        : ""),
                 ["recorded_at"] = now.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'"),
             };
 
@@ -638,7 +641,7 @@ public sealed class DashboardService : BackgroundService
                 ["som_version"] = "0.2.0",
                 ["message_id"] = Guid.NewGuid().ToString(),
                 // Thread the staged output's lifecycle: same correlation, caused by the staged message.
-                ["correlation_id"] = envelope["correlation_id"] is JsonValue cv && cv.TryGetValue<string>(out var corr) ? corr : Guid.NewGuid().ToString(),
+                ["correlation_id"] = envelope?["correlation_id"] is JsonValue cv && cv.TryGetValue<string>(out var corr) ? corr : Guid.NewGuid().ToString(),
                 ["message_type"] = "system.audit",
                 ["timestamp"] = now.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'"),
                 ["originating_system"] = new JsonObject
@@ -652,19 +655,23 @@ public sealed class DashboardService : BackgroundService
                 ["topic"] = _options.AuditTopic,
                 ["payload"] = auditPayload,
             };
-            if (envelope["message_id"] is JsonValue mv && mv.TryGetValue<string>(out var causation))
+            if (envelope?["message_id"] is JsonValue mv && mv.TryGetValue<string>(out var causation))
                 auditEnvelope["causation_id"] = causation;
 
+            // Deliberately no cancellation token: this is post-commit work and must not be
+            // abandonable; the producer's 10s MessageTimeoutMs bounds it.
             await _producer.ProduceAsync(_options.AuditTopic,
-                new Message<string, string> { Key = pending.StoryKey ?? pending.OutputId, Value = auditEnvelope.ToJsonString() }, ct);
+                new Message<string, string> { Key = pending.StoryKey ?? pending.OutputId, Value = auditEnvelope.ToJsonString() });
             _logger.LogInformation(
                 "Dashboard: decision audit {Action} for output {OutputId} recorded on {Topic} (reviewer {Reviewer})",
                 action, pending.OutputId, _options.AuditTopic, reviewer);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex)
         {
             // Same posture as MediaCoordinator's WITHHELD path: if the audit can't be
-            // recorded, say exactly that — the decision stands but is unrecorded.
+            // recorded, say exactly that — the decision stands but is unrecorded. No OCE
+            // carve-out: with no token in play, cancellation isn't a legitimate signal
+            // here, and letting one escape would skip this log and the caller's broadcast.
             _logger.LogError(ex,
                 "Dashboard: decision audit {Action} for output {OutputId} could NOT be confirmed on {Topic} — the clearance may exist only in topic annotations",
                 action, pending.OutputId, _options.AuditTopic);
@@ -672,25 +679,50 @@ public sealed class DashboardService : BackgroundService
     }
 
     /// <summary>
-    /// Best-effort mapping of a staged output onto the locked audit target set
-    /// (LINK | ASSET | TELLING). Warnings/suggestions scope to their firing level:
-    /// "link:{id}" → LINK; else the first affected_fields path "assets.{id}.…" → ASSET;
-    /// else ASSET keyed by story (demo-grade fallback, still schema-valid).
+    /// Map a staged output onto the locked audit target set (LINK | ASSET | TELLING), most
+    /// specific tier first: an explicit link:/asset: scope wins; else any affected_fields
+    /// path "assets.{id}.…" names the asset; else a bare "assets"/"assets[]…" field
+    /// resolves through the story cache when the story has exactly ONE asset (multi-asset
+    /// stories stay story-scoped — precise per-asset anchors arrive with the firing-anchor
+    /// upgrade). Story-scoped remainder returns StoryFallback=true: v0.3.1 has no STORY
+    /// target kind (v0.3.2 candidate), so the caller must label the id as a story key.
     /// </summary>
-    private static (string Kind, string Id) ResolveAuditTarget(JsonNode? payload)
+    private (string Kind, string Id, bool StoryFallback) ResolveAuditTarget(JsonObject? payload)
     {
         var scope = payload?["scope"] is JsonValue scv && scv.TryGetValue<string>(out var sc) ? sc : null;
         if (scope is not null && scope.StartsWith("link:", StringComparison.Ordinal))
-            return ("LINK", scope["link:".Length..]);
+            return ("LINK", scope["link:".Length..], false);
+        if (scope is not null && scope.StartsWith("asset:", StringComparison.Ordinal))
+            return ("ASSET", scope["asset:".Length..], false);
 
-        if (payload?["affected_fields"] is JsonArray fields && fields.Count > 0)
+        var storyId = payload?["story_id"] is JsonValue sv2 && sv2.TryGetValue<string>(out var s2) ? s2 : null;
+
+        if (payload?["affected_fields"] is JsonArray fields)
         {
-            var parts = fields[0] is JsonValue fv && fv.TryGetValue<string>(out var f) ? f.Split('.') : null;
-            if (parts is { Length: >= 2 } && parts[0] == "assets")
-                return ("ASSET", parts[1]);
+            var sawBareAssets = false;
+            foreach (var field in fields)
+            {
+                if (field is not JsonValue fv || !fv.TryGetValue<string>(out var f)) continue;
+                var parts = f.Split('.');
+                if (parts[0] == "assets" && parts.Length >= 2 && parts[1].Length > 0)
+                    return ("ASSET", parts[1], false);
+                if (parts[0] is "assets" or "assets[]") sawBareAssets = true;
+            }
+            if (sawBareAssets && SingleAssetIdFor(storyId) is { } onlyAsset)
+                return ("ASSET", onlyAsset, false);
         }
 
-        return ("ASSET", payload?["story_id"] is JsonValue sv2 && sv2.TryGetValue<string>(out var s2) ? s2 : "unknown");
+        return ("ASSET", storyId ?? "unknown", true);
+    }
+
+    /// <summary>The story's asset_id iff the cached story has exactly one asset — the only
+    /// case where a bare "assets" affected-field pins to an asset without guessing.</summary>
+    private string? SingleAssetIdFor(string? storyId)
+    {
+        if (storyId is null || !_stories.TryGetValue(storyId, out var node)) return null;
+        var story = (node as JsonObject)?["payload"] as JsonObject ?? node as JsonObject;
+        if (story?["assets"] is not JsonArray { Count: 1 } assets) return null;
+        return assets[0] is JsonObject a && a["asset_id"] is JsonValue v && v.TryGetValue<string>(out var id) ? id : null;
     }
 
     private sealed record PendingOutput(

--- a/som-hackathon-starter-dotnet/README.md
+++ b/som-hackathon-starter-dotnet/README.md
@@ -186,7 +186,7 @@ Each seed story includes a `content_refs` array pointing to `GET /api/content/{s
 | `som.skills.rejected` | Dashboard (on reject) | audit | Rejected outputs (with `rejected_by`) |
 | `som.skills.runs` | SkillWorker | Dashboard | Audit record per skill execution (latency, outcome) |
 | `som.delivery.media_available` | MockMamService (TAMS stand-in) | **MediaCoordinatorService** (acts) · Dashboard (event log) | Media-arrival announcements — see [`docs/SOM-v0.3.1-distribution-contracts.md`](docs/SOM-v0.3.1-distribution-contracts.md) |
-| `som.system.audit` | MediaCoordinatorService (`WITHHELD` non-action reports) | Dashboard (event log) | Governance trail; WS1 (Aug) adds the remaining producers |
+| `som.system.audit` | MediaCoordinatorService (`WITHHELD` non-actions) · Dashboard (gate decisions `CLEARED`/`WITHHELD`) | Dashboard (event log) | Governance trail; WS1 (Aug) adds the remaining producers |
 
 Topics auto-create on first publish in local mode. The coordinator is the participant that *acts* on media arrivals (see below); the dashboard tails both distribution topics for the bus event log (`MEDIA` / `AUDIT` lines + topic chips). Full envelopes: Kafka UI (:8080 with the bundled compose).
 

--- a/som-hackathon-starter-dotnet/docs/SOM-v0.3.1-IBC-Gap-Analysis.md
+++ b/som-hackathon-starter-dotnet/docs/SOM-v0.3.1-IBC-Gap-Analysis.md
@@ -66,8 +66,8 @@ Premise propagation with `change_detected_at` (seed 01:43–44) ≈ Beat 3 (Accu
 1. Payload migration (§2) + phases (§3) — unblocks everything, low risk. **[RATIFIED]**
 2. Skill-warning contract (§4 output) — small, high value. **[RATIFIED]**
 3. `som.link.*` + gates (§1) — Reach + Sync + Demo 2 partial fire. **[PENDING]**
-4. `delivery.media_available` + `media_refs`/`authenticity_credential` — Media + Provenance. **[PENDING]**
-5. `som.system.audit` (§1) — Demo 2 close. **[PENDING]**
+4. `delivery.media_available` + `media_refs`/`authenticity_credential` — Media + Provenance. **[LANDED — mock MAM producer + media coordinator consumer]**
+5. `som.system.audit` (§1) — Demo 2 close. **[PARTIAL — two producers live: coordinator `WITHHELD` non-actions, dashboard gate decisions; WS1 adds the rest]**
 6. Firing-rule upgrade (§4) — richest; do last / scope down. **[PENDING]**
 
 See `SOM-v0.3.1-Migration-Log.md` for the running record of changes on this branch.

--- a/som-hackathon-starter-dotnet/docs/SOM-v0.3.1-distribution-contracts.md
+++ b/som-hackathon-starter-dotnet/docs/SOM-v0.3.1-distribution-contracts.md
@@ -4,7 +4,7 @@ _Service: `som-hackathon-starter-dotnet` · schema pack: [`schema/v0.3.1-propose
 
 This is the partner-facing reference for the **v0.3.1 distribution layer** — the message families that sit under `som.link.*`, `som.telling.*`, `som.delivery.*`, and `som.system.*`. For each family: the topic, the JSON Schema, one canonical example, and which IBC demo beat it proves. Every payload here validates against the vendored schemas via [`schema/validate.py`](../schema/validate.py).
 
-> **Schema vs producer status.** All the schemas below are **ratified v0.3.1** and safe to build against. The reference implementation covers them unevenly — `som.delivery.media_available` has a mock producer (`MockMamService`) **and a reference consumer** (`MediaCoordinatorService`, which flips `acquisition_state` on capture-complete and records `WITHHELD` audits for unmatched arrivals); `som.system.audit` has that one live producer; `som.link.*` and `som.telling.*` are the 6 Aug hackathon build (WS1). "Producer" columns say which is which. The contract is stable regardless of implementation status — integrate against the schema.
+> **Schema vs producer status.** All the schemas below are **ratified v0.3.1** and safe to build against. The reference implementation covers them unevenly — `som.delivery.media_available` has a mock producer (`MockMamService`) **and a reference consumer** (`MediaCoordinatorService`, which flips `acquisition_state` on capture-complete and records `WITHHELD` audits for unmatched arrivals); `som.system.audit` has **two** live producers (the coordinator's `WITHHELD` non-actions and the dashboard's human gate decisions — approve → `CLEARED`, reject → `WITHHELD`); `som.link.*` and `som.telling.*` are the 6 Aug hackathon build (WS1). "Producer" columns say which is which. The contract is stable regardless of implementation status — integrate against the schema.
 
 ---
 
@@ -51,7 +51,7 @@ Envelope rules that bite integrators:
 | `som.delivery.media_available` | `delivery.media_available` | MockMamService (TAMS stand-in) | MediaCoordinatorService (reference consumer) | 🟡 mock producer + reference consumer |
 | `som.link.committed` · `.gate_changed` · `.withdrawn` | `link.committed`, `link.gate_changed`, `link.withdrawn` | (WS1) | (WS1) → maintains `usage[]` | ⏳ schema ready, Aug build |
 | `som.telling.started` · `.ended` · `.exposed` | `telling.started`, `telling.ended`, `telling.exposed` | (WS1) | (WS1) → derives on-air state | ⏳ schema ready, Aug build |
-| `som.system.audit` | `system.audit` | MediaCoordinatorService (`WITHHELD` non-actions) · (WS1 for the rest) | audit / dashboard | 🟡 one producer live |
+| `som.system.audit` | `system.audit` | MediaCoordinatorService (`WITHHELD` non-actions) · Dashboard (gate decisions `CLEARED`/`WITHHELD`) · (WS1 for the rest) | audit / dashboard | 🟡 two producers live |
 
 Message-type names are the **suffixed** forms on the wire (e.g. `skill.warning.raised`, not `skill.warning`).
 
@@ -157,7 +157,13 @@ The clearance/suppression audit trail. Distinct from `som.skills.runs` (which re
 ```
 
 - `action` ∈ `CLEARED` · `SUPPRESSED` · `WITHHELD` · `OVERRIDDEN`. `target.kind` ∈ `LINK` · `ASSET` · `TELLING`.
-- **Proves:** D2·B3 clearance/suppression trail. `WITHHELD` also carries the "safe-state stop / non-action report" from the skills-model work (a system actor records that it declined to act).
+- **Proves:** D2·B3 clearance/suppression trail. `WITHHELD` also carries the "safe-state stop / non-action report" from the skills-model work — any actor, system **or human**, records that it declined to act.
+
+**Live producers today.** The media coordinator (`WITHHELD` on unmatched arrivals — the system safe-state stop) and the dashboard's human gate (**approve → `CLEARED`**, **reject → `WITHHELD`**, `actor_type: "user"`, `causation_id` = the staged output's `message_id`). A human reject is `WITHHELD`, not `SUPPRESSED`, by decision: rejection is **terminal for that output instance** (a re-run mints a new output) — "no outstanding decision changes this" — whereas `SUPPRESSED` is about held *content* never linked to air. WS1 (Aug) adds the remaining producers.
+
+**Target mapping for gate decisions.** A staged output maps onto the locked `LINK | ASSET | TELLING` set most-specific-first: an explicit `link:{id}`/`asset:{id}` scope wins; else an `assets.{id}.…` affected-field names the asset; else a bare `assets` affected-field resolves through the story cache when the story has exactly **one** asset. A **story-scoped** decision has no honest home in the locked set — the record ships `kind: ASSET` carrying the **story** key and says so explicitly in `reason`. Consumers MUST NOT join such an id against assets; a `STORY` target kind is a v0.3.2 candidate.
+
+Partition keys are mixed on this topic by design — the coordinator keys audits by **asset id**, the dashboard by **story key**. Do not rely on per-key ordering across producers.
 
 ---
 

--- a/som-hackathon-starter-dotnet/docs/USER-GUIDE.md
+++ b/som-hackathon-starter-dotnet/docs/USER-GUIDE.md
@@ -226,6 +226,6 @@ Full endpoint list: [README → API endpoints](../README.md#api-endpoints).
 | **Advert** | A skill's machine-readable declaration of what it operates on / fires on / produces |
 | **Recall** | The executor's deterministic advert-matching step — deciding which skills run |
 | **Staging** | The pre-approval topic; nothing reaches the production bus without a human decision |
-| **Safe-state stop** | When the correct action is unclear, do nothing and *record* the non-action (`WITHHELD` on `som.system.audit`) |
+| **Safe-state stop** | When the correct action is unclear, do nothing and *record* the non-action (`WITHHELD` on `som.system.audit`). `WITHHELD` is also how the dashboard records a human **reject** — a terminal non-action on that output instance |
 | **Envelope** | The outer wrapper every SOM message shares; the payload inside is what schemas validate |
 | **Extension** | `payload.extensions["com.{vendor}.{field}"]` — the sanctioned place for not-yet-ratified fields |

--- a/som-hackathon-starter-dotnet/docs/dashboard-guide.md
+++ b/som-hackathon-starter-dotnet/docs/dashboard-guide.md
@@ -43,7 +43,7 @@ These are separate surfaces — knowing which is which is most of the learning c
 
 Every message on every subscribed topic, newest first — one line per message with a per-topic summary (stories show headline; runs show outcome + latency; MAM emits show `MEDIA <source> range=<timerange>`). The **topic chips** filter the view and double as live counters. **Clear** empties only this log display.
 
-`som.delivery.media_available` and `som.system.audit` appear here for **observability** — the dashboard tails them for the log. The participant that *acts* on media arrivals is `MediaCoordinatorService` (see workflow 3); the remaining audit producers and the `som.link.*`/`som.telling.*` families are the WS1 August build.
+`som.delivery.media_available` appears here for **observability** — the dashboard tails it for the log; the participant that *acts* on media arrivals is `MediaCoordinatorService` (see workflow 3). `som.system.audit` carries the dashboard's **own** gate decisions too: every approve records `CLEARED` and every reject records `WITHHELD` there, alongside the coordinator's `WITHHELD` non-actions. The remaining audit producers and the `som.link.*`/`som.telling.*` families are the WS1 August build.
 
 ## Other header controls
 


### PR DESCRIPTION
## What

The agreed follow-ups from the #323 review — findings #1–#5 plus the smaller notes, in one commit (code: `DashboardService.cs`; docs: 5 files).

**#1 — audit targets are now real, and honest when they can't be.** `ResolveAuditTarget` tiers, most-specific first: an explicit `link:{id}`/`asset:{id}` scope wins (the scope contract defines all three levels); any `assets.{id}.…` affected-field names the asset; a bare `assets` affected-field resolves through the story cache when the story has exactly **one** asset — the capture rule's warnings now target the real asset id on single-asset stories. Multi-asset stories stay story-scoped (no guessing; per-asset anchors arrive with the tracked firing-anchor upgrade), and story-scoped records now label themselves explicitly in `reason`: *target.id is the STORY key, not an asset id*. A `STORY` target kind goes to the WG as a v0.3.2 candidate.

**#3 — WITHHELD for a human reject, ratified and written down** in the contracts doc: rejection is terminal for that output *instance* (a re-run mints a new output) — "no outstanding decision changes this" — whereas `SUPPRESSED` is about held *content* never linked to air.

**#4 — audit off the UI's critical path**: the emit now sits below `BroadcastAsync`, so a degraded broker can't hang the operator's confirmation up to 10s behind the audit produce.

**#5 — OCE filter dropped, dead `ct` removed**: the audit is deliberately unabandonable post-commit work (bounded by the producer's 10s `MessageTimeoutMs`); with no token in play, a cancellation-shaped escape would only skip the error log and the caller's return.

**#2 — five docs de-drifted**: README topic table, contracts doc (two live producers, gate-decision target mapping, mixed partition-key note), dashboard guide, user guide glossary, gap-analysis items 4/5. Also the `as JsonObject` casts so the tolerant-reads claim is true as written.

## Verification

`dotnet build` 0/0 · Snyk clean · `schema/validate.py` all-pass. Live on the bus (isolated instance): capture warning on a **single-asset** story → `target: ASSET/only-asset-77` (cache tier, real asset id); story-scoped style warning → story key + explicit marker; reject → `WITHHELD` emitted after the broadcast; all three captured envelopes validate against the audit schema; correlation echoed from the triggering story envelope.

## Merge note

A second PR (decision envelope integrity, from the 30 Jul independent architecture review) is stacked on this branch — merge this first.
