### PR TITLE
SomHackathon: decision messages are schema-valid envelopes with honest attribution

### DIFF
--- a/som-hackathon-starter-dotnet/DashboardService.cs
+++ b/som-hackathon-starter-dotnet/DashboardService.cs
@@ -253,20 +253,25 @@ public sealed class DashboardService : BackgroundService
 
         if (decision.Equals("approve", StringComparison.OrdinalIgnoreCase))
         {
-            // Annotate and republish to the production bus. If the produce fails, put the
-            // pending item BACK — a broker blip must not silently discard a staged warning.
-            var enriched = pending.Output.DeepClone();
-            enriched["approved_by"] = reviewer ?? "dashboard-user";
-            enriched["approved_at"] = DateTimeOffset.UtcNow.ToString("o");
-
+            // Republish to the production bus in a FRESH dashboard-attributed envelope —
+            // envelope-level approved_by/at writes were schema-invalid (envelope is
+            // additionalProperties:false). The build happens INSIDE the try: constructing
+            // the envelope materializes vendor JSON (payload.extensions) for the first
+            // time and can throw (e.g. duplicate keys) — any failure here must put the
+            // pending item BACK, never silently discard a staged warning.
             try
             {
+                var enriched = BuildDecisionEnvelope(pending, _options.SkillEventsTopic,
+                    ("approved_by", reviewer ?? "dashboard-user"),
+                    ("approved_at", DateTimeOffset.UtcNow.ToString("o")));
                 await _producer.ProduceAsync(_options.SkillEventsTopic,
                     new Message<string, string> { Key = key, Value = enriched.ToJsonString() }, ct);
             }
-            catch
+            catch (Exception ex)
             {
                 _pending[outputId] = pending;
+                _logger.LogError(ex,
+                    "Approve of {OutputId} failed before/at produce — pending item restored for retry", outputId);
                 throw;
             }
 
@@ -290,18 +295,20 @@ public sealed class DashboardService : BackgroundService
 
         if (decision.Equals("reject", StringComparison.OrdinalIgnoreCase))
         {
-            var enriched = pending.Output.DeepClone();
-            enriched["rejected_by"] = reviewer ?? "dashboard-user";
-            enriched["rejected_at"] = DateTimeOffset.UtcNow.ToString("o");
-
+            // Build inside the try — same restore guarantee as the approve branch.
             try
             {
+                var enriched = BuildDecisionEnvelope(pending, _options.SkillRejectedTopic,
+                    ("rejected_by", reviewer ?? "dashboard-user"),
+                    ("rejected_at", DateTimeOffset.UtcNow.ToString("o")));
                 await _producer.ProduceAsync(_options.SkillRejectedTopic,
                     new Message<string, string> { Key = key, Value = enriched.ToJsonString() }, ct);
             }
-            catch
+            catch (Exception ex)
             {
                 _pending[outputId] = pending;
+                _logger.LogError(ex,
+                    "Reject of {OutputId} failed before/at produce — pending item restored for retry", outputId);
                 throw;
             }
 
@@ -393,7 +400,7 @@ public sealed class DashboardService : BackgroundService
     /// and broadcasts a dashboard refresh.
     /// </summary>
     private async Task<RerunResult> RepublishAsync(
-        string storyId, Action<JsonNode> mutate, CancellationToken ct)
+        string storyId, Action<JsonNode> mutate, CancellationToken ct, string? causationId = null)
     {
         if (!_stories.TryGetValue(storyId, out var cached))
             return new RerunResult(false, "story_not_seen", 0);
@@ -410,11 +417,25 @@ public sealed class DashboardService : BackgroundService
         payload["updated_at"] = DateTimeOffset.UtcNow.ToString("o");
 
         // A republish is a NEW message: fresh message_id + timestamp on the envelope,
-        // same correlation_id so the story lifecycle stays threaded.
+        // same correlation_id so the story lifecycle stays threaded, and the DASHBOARD
+        // as originating_system — the envelope records the act (this mutation), not the
+        // original publisher's statement. Any stale causation_id from the cached copy's
+        // own history is removed first: a fresh message must not claim an old cause.
         if (clone["payload"] is not null)
         {
             clone["message_id"] = Guid.NewGuid().ToString();
             clone["timestamp"] = DateTimeOffset.UtcNow.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'");
+            clone["originating_system"] = DashboardIdentity();
+            ((JsonObject)clone).Remove("causation_id");
+            if (causationId is not null) clone["causation_id"] = causationId;
+        }
+        else
+        {
+            // Bare-payload cached story (v0.2 shortcut): there is no envelope to stamp,
+            // so identity/causation degrade — loudly, not silently.
+            _logger.LogWarning(
+                "Republish of {StoryId} is a bare payload: no envelope to stamp dashboard identity on{CausationNote}",
+                storyId, causationId is null ? "" : $" (causation {causationId} dropped)");
         }
 
         var clearedIds = _pending.Where(kv =>
@@ -470,8 +491,8 @@ public sealed class DashboardService : BackgroundService
     /// coordinator). Same semantics as the lifecycle-simulator endpoints: bump
     /// sequence_number, stamp updated_at, clear stale pending, republish.
     /// </summary>
-    public Task<RerunResult> MutateStoryAsync(string storyId, Action<JsonNode> mutate, CancellationToken ct) =>
-        RepublishAsync(storyId, mutate, ct);
+    public Task<RerunResult> MutateStoryAsync(string storyId, Action<JsonNode> mutate, CancellationToken ct, string? causationId = null) =>
+        RepublishAsync(storyId, mutate, ct, causationId);
 
     /// <summary>
     /// Reset the dashboard view: clear the pending queue and tell every connected dashboard
@@ -602,6 +623,64 @@ public sealed class DashboardService : BackgroundService
         base.Dispose();
     }
 
+    /// <summary>The dashboard's originating_system block — one definition so the decision
+    /// envelopes and the audit records agree about who acted.</summary>
+    private static JsonObject DashboardIdentity() => new()
+    {
+        ["system_id"] = "ibc-poc-dashboard",
+        ["system_type"] = "editorial_dashboard",
+        ["system_name"] = "Staging Dashboard (human approval gate)",
+        ["vendor"] = "ibc-poc",
+        ["version"] = "0.1",
+    };
+
+    /// <summary>
+    /// A decision republish is a NEW message: fresh message_id/timestamp, topic = the
+    /// actual destination, the dashboard as originating_system (the envelope records the
+    /// act), correlation threaded from the staged envelope, causation_id = the staged
+    /// message_id. The payload rides unchanged except the decision facts, which live
+    /// under payload.extensions (com.ibc-poc.*) — both the envelope and the warning
+    /// payload are additionalProperties:false, so extensions are the only open surface;
+    /// the governance-grade record is the som.system.audit entry.
+    /// </summary>
+    private JsonObject BuildDecisionEnvelope(
+        PendingOutput pending, string topic, params (string Key, string Value)[] annotations)
+    {
+        var staged = pending.Output as JsonObject;
+        var payload = (staged?["payload"] as JsonObject ?? staged)?.DeepClone() as JsonObject ?? new JsonObject();
+        if (payload["extensions"] is not JsonObject ext)
+        {
+            // Present-but-non-object is a vendor malformation worth a trace — replacing it
+            // silently would be indistinguishable from the ordinary missing case.
+            if (payload["extensions"] is not null)
+                _logger.LogWarning(
+                    "Staged output {OutputId}: payload.extensions was not an object — replaced to carry decision stamps (original value survives on the staging topic)",
+                    pending.OutputId);
+            payload["extensions"] = ext = new JsonObject();
+        }
+        foreach (var (k, v) in annotations) ext[$"com.ibc-poc.{k}"] = v;
+
+        var now = DateTimeOffset.UtcNow;
+        var messageType =
+            staged?["message_type"] is JsonValue mtv && mtv.TryGetValue<string>(out var mt) ? mt
+            : payload["message_type"] is JsonValue pmv && pmv.TryGetValue<string>(out var pmt) ? pmt
+            : "skill.warning.raised";
+        var envelope = new JsonObject
+        {
+            ["som_version"] = "0.2.0",
+            ["message_id"] = Guid.NewGuid().ToString(),
+            ["correlation_id"] = staged?["correlation_id"] is JsonValue cv && cv.TryGetValue<string>(out var corr) ? corr : Guid.NewGuid().ToString(),
+            ["message_type"] = messageType,
+            ["timestamp"] = now.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'"),
+            ["originating_system"] = DashboardIdentity(),
+            ["topic"] = topic,
+            ["payload"] = payload,
+        };
+        if (staged?["message_id"] is JsonValue mv && mv.TryGetValue<string>(out var causation))
+            envelope["causation_id"] = causation;
+        return envelope;
+    }
+
     /// <summary>
     /// Record a human gate decision on som.system.audit — the governance-grade act.
     /// approve → CLEARED; reject → WITHHELD (terminal for this output instance; a
@@ -644,14 +723,7 @@ public sealed class DashboardService : BackgroundService
                 ["correlation_id"] = envelope?["correlation_id"] is JsonValue cv && cv.TryGetValue<string>(out var corr) ? corr : Guid.NewGuid().ToString(),
                 ["message_type"] = "system.audit",
                 ["timestamp"] = now.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'"),
-                ["originating_system"] = new JsonObject
-                {
-                    ["system_id"] = "ibc-poc-dashboard",
-                    ["system_type"] = "editorial_dashboard",
-                    ["system_name"] = "Staging Dashboard (human approval gate)",
-                    ["vendor"] = "ibc-poc",
-                    ["version"] = "0.1",
-                },
+                ["originating_system"] = DashboardIdentity(),
                 ["topic"] = _options.AuditTopic,
                 ["payload"] = auditPayload,
             };

--- a/som-hackathon-starter-dotnet/MediaCoordinatorService.cs
+++ b/som-hackathon-starter-dotnet/MediaCoordinatorService.cs
@@ -194,6 +194,8 @@ public sealed class MediaCoordinatorService : BackgroundService
         }
 
         var matchedAsset = false;
+        // causationId: the arrival's message_id, so the republished story version records
+        // what caused the flip (the dashboard stamps its own identity as the producer).
         var flip = await _dashboard.MutateStoryAsync(storyId, story =>
         {
             var assets = story["assets"] as JsonArray;
@@ -213,7 +215,7 @@ public sealed class MediaCoordinatorService : BackgroundService
                     }
                 }
             }
-        }, ct);
+        }, ct, causationId);
 
         if (flip.Ok && !matchedAsset)
         {

--- a/som-hackathon-starter-dotnet/README.md
+++ b/som-hackathon-starter-dotnet/README.md
@@ -102,7 +102,7 @@ If the broker's port is exposed on the Docker host but not on a network the cont
             (production bus)
 ```
 
-The skill worker never publishes directly to `som.skills.events`. Every output flows through `som.skills.staging`; the dashboard's approve/reject API republishes the message to the production or rejection topic, annotating with `approved_by` / `rejected_by` for audit.
+The skill worker never publishes directly to `som.skills.events`. Every output flows through `som.skills.staging`; the dashboard's approve/reject API republishes the payload to the production or rejection topic in a fresh dashboard-attributed envelope (new `message_id`/`timestamp`, `causation_id` = the staged message). `approved_by` / `rejected_by` ride `payload.extensions` (`com.ibc-poc.*`) — the envelope schema is closed — and the governance-grade record of the decision lands on `som.system.audit`.
 
 ## Project structure
 
@@ -183,7 +183,7 @@ Each seed story includes a `content_refs` array pointing to `GET /api/content/{s
 | `som.story.context` | TestProducer | SkillWorker, Dashboard | Inbound stories from the newsroom |
 | `som.skills.staging` | SkillWorker | Dashboard | Skill outputs awaiting human decision |
 | `som.skills.events` | Dashboard (on approve) | downstream | Approved outputs on the production bus |
-| `som.skills.rejected` | Dashboard (on reject) | audit | Rejected outputs (with `rejected_by`) |
+| `som.skills.rejected` | Dashboard (on reject) | audit | Rejected outputs (`rejected_by` in `payload.extensions`) |
 | `som.skills.runs` | SkillWorker | Dashboard | Audit record per skill execution (latency, outcome) |
 | `som.delivery.media_available` | MockMamService (TAMS stand-in) | **MediaCoordinatorService** (acts) · Dashboard (event log) | Media-arrival announcements — see [`docs/SOM-v0.3.1-distribution-contracts.md`](docs/SOM-v0.3.1-distribution-contracts.md) |
 | `som.system.audit` | MediaCoordinatorService (`WITHHELD` non-actions) · Dashboard (gate decisions `CLEARED`/`WITHHELD`) | Dashboard (event log) | Governance trail; WS1 (Aug) adds the remaining producers |

--- a/som-hackathon-starter-dotnet/docs/USER-GUIDE.md
+++ b/som-hackathon-starter-dotnet/docs/USER-GUIDE.md
@@ -138,7 +138,7 @@ Each rule has `rule_id`, `type`, `config`, `default_severity` (`hold` / `flag` /
 3. Optional **AI review** (`🤖`): ships your skill + seeds + dry-run result to an LLM for structured feedback ([setup](../README.md#skill-validation-3-layers)).
 4. **Go live**: publish seeds / run scenarios and watch your skill's run cards and staged outputs. For a `field_changed` rule, mutate a story (Lifecycle panel, or the media-arrival scenario for `acquisition_state`) so there's a transition to detect.
 
-Your outputs ride the same approval gate as everything else: staged → human decision → `som.skills.events` or `som.skills.rejected`, stamped with the reviewer.
+Your outputs ride the same approval gate as everything else: staged → human decision → `som.skills.events` or `som.skills.rejected`, republished in a fresh dashboard-attributed envelope with the reviewer stamped in `payload.extensions` and the decision recorded on `som.system.audit`.
 
 ## 7. Integrating your own system
 

--- a/som-hackathon-starter-dotnet/docs/architecture.md
+++ b/som-hackathon-starter-dotnet/docs/architecture.md
@@ -94,8 +94,8 @@ The worker never publishes directly to the production bus (`som.skills.events`).
 
 The **DashboardService** consumes `som.skills.staging` and holds outputs in memory. Editors see them in the dashboard's "Pending" lane and decide:
 
-- **Approve** → message is republished to `som.skills.events` with `approved_by` annotation
-- **Reject** → message is republished to `som.skills.rejected` with `rejected_by` annotation
+- **Approve** → payload republished to `som.skills.events` in a **fresh dashboard-attributed envelope** (new `message_id`/`timestamp`, `causation_id` = the staged message); `approved_by`/`approved_at` ride `payload.extensions` (`com.ibc-poc.*`), and a `CLEARED` record lands on `som.system.audit`
+- **Reject** → same shape to `som.skills.rejected` (`rejected_by`/`rejected_at` in extensions) plus a `WITHHELD` audit record
 
 This is the core safety pattern: no skill output reaches production without a human decision.
 

--- a/som-hackathon-starter-dotnet/wwwroot/index.html
+++ b/som-hackathon-starter-dotnet/wwwroot/index.html
@@ -872,6 +872,14 @@ function unwrapSom(node) {
   for (const k of ['message_type', 'approved_by', 'approved_at', 'rejected_by', 'rejected_at', 'timestamp']) {
     if (out[k] === undefined && node[k] !== undefined) out[k] = node[k];
   }
+  // Decision stamps now ride payload.extensions (com.ibc-poc.*) — the envelope is
+  // additionalProperties:false, so the old envelope-level stamps were schema-invalid.
+  // Lift them to the flat keys the renderers read; the envelope-level loop above still
+  // covers pre-fix history on the bus.
+  for (const k of ['approved_by', 'approved_at', 'rejected_by', 'rejected_at']) {
+    const v = out.extensions ? out.extensions['com.ibc-poc.' + k] : undefined;
+    if (out[k] === undefined && v !== undefined) out[k] = v;
+  }
   return out;
 }
 


### PR DESCRIPTION
## What

Fixes the three decision-path defects from the 30 Jul independent architecture review (`SOM-Independent-Architecture-Review-2026-07-30`):

1. **Decision messages were schema-invalid.** `approved_by`/`rejected_by`/`*_at` were written at the envelope top level; the envelope schema is `additionalProperties: false`, so every message ever produced to `som.skills.events`/`som.skills.rejected` failed validation.
2. **Stale identity.** The republished clone kept the staged `message_id`/`timestamp`, and `topic` still said `som.skills.staging` on a message produced elsewhere.
3. **`RepublishAsync` forged attribution.** Dashboard mutations (advance-phase, add-compliance, the coordinator's CAPTURED flip) went onto `som.story.context` still attributed to the seed's original publisher.

## Fix shape — and which branch was taken, and why

Decisions now republish the staged payload in a **fresh dashboard-attributed envelope** (`BuildDecisionEnvelope`): new `message_id`/`timestamp`, `topic` = the actual destination, `originating_system` = a shared `DashboardIdentity()` (the same object the #323 audit records use, so the two can't drift), `correlation_id` threaded from the staged envelope, `causation_id` = the staged `message_id`.

**The decision stamps ride `payload.extensions["com.ibc-poc.*"]`** — not the payload root, and not audit-only. Rationale: the warning payload is also `additionalProperties: false`, so root-level annotation is out; and pure audit-only would have broken the dashboard SPA's Decisions lane, which renders reviewer attribution from the wire. Extensions are the payload's designed open surface (`patternProperties ^com\.`), keep attribution wire-visible, and the governance-grade record remains the `som.system.audit` entry. The SPA's `unwrapSom` lifts the extension stamps, with the envelope-level fallback retained so pre-fix bus history still renders.

`RepublishAsync` re-stamps `originating_system` with the dashboard identity, **removes any stale `causation_id`** inherited from the cached copy's own history (a fresh message must not claim an old cause), and threads an optional causation id — the media coordinator passes its arrival's `message_id`, so a CAPTURED story flip now records what caused it. Bare-payload cached stories (v0.2 shortcut) have no envelope to stamp; that degradation now logs a warning instead of passing silently.

Hardening from the pre-open review pass (three agents): the envelope build moved **inside** the produce try — constructing it materializes vendor JSON (`payload.extensions`) for the first time and can throw on duplicate keys, which previously would have lost the pending item outside the restore window (reproduced empirically on this SDK); the restore now also logs. A present-but-non-object `extensions` replacement is logged rather than silent.

## Verification

- `dotnet build` 0/0 · Snyk clean · `python3 schema/validate.py` all-pass · grep gate: no envelope-level decision writes remain.
- Live, captured off the bus: **approve and reject envelopes validate against `som-v0.3-envelope.schema.json`** — fresh `message_id`, correct `topic`, dashboard `originating_system`, correlation threaded, `causation_id` exact-matched to the staged message, stamps present only under `payload.extensions`.
- Advance-phase and the coordinator CAPTURED flip republish as schema-valid dashboard-attributed envelopes; the flip's `causation_id` exact-matches the arrival's `message_id`; a subsequent mutation of the same story does **not** inherit that causation (stale-causation removal verified against a settled predecessor).
- CLEARED/WITHHELD audit records unchanged, actor matches the new envelope identity; produce-failure restore regression-checked.

## Notes

- `som.skills.events` has no consumers in this repo beyond the dashboard's own log tail — no downstream breakage.
- Follow-up PR (in flight, stacked on this): the #324 post-merge review round — staging-time story snapshot for audit target resolution, `[story-scoped]` machine-matchable reason prefix, remaining doc sweep.
