### PR TITLE
feat(infra): add Cloud DNS inbound policy, fix Cloud Build trigger path, and update remote access docs

### DIFF
--- a/som-hackathon-starter-dotnet/README.md
+++ b/som-hackathon-starter-dotnet/README.md
@@ -379,46 +379,53 @@ Due to circular dependencies between Artifact Registry, Cloud Build, and Cloud R
     terraform apply
     ```
 
-### Connecting Remotely via Tailscale (for Developers)
+### Remote Access & Testing Options
 
-To subscribe to Managed Kafka topics or run a local skill worker against the cloud cluster, developers need network-level access to the GCP VPC. We use Tailscale as a subnet router.
+Depending on your laptop environment (personal vs. locked-down corporate device), pick the option that works best for you:
 
-#### 1. Administrator Setup (Once after deployment)
-If you did not provide a `tailscale_auth_key` in `terraform.tfvars`, the subnet router VM was provisioned but not authenticated.
-1. SSH into the router VM using the command from Terraform outputs:
+#### Option A: Corporate Laptop / Zero VPN (Recommended for Restricted Devices)
+
+If third-party VPN apps like Tailscale are blocked on your corporate machine:
+
+1. **Use the Live Cloud Run Gateway**:
+   - The central skill worker and dashboard are hosted at `https://som-skill-worker-582032169035.europe-west1.run.app`.
+   - **Interactive Dashboard**: Open the URL in any web browser to view live story pipelines and approve/reject staged warnings.
+   - **Upload Skills via REST API**:
+     ```bash
+     curl -X POST https://som-skill-worker-582032169035.europe-west1.run.app/api/skills \
+       -H "Content-Type: application/json" \
+       -d @skills/your-skill.json
+     ```
+2. **Develop & Test Locally using Docker**:
+   - Start local KRaft Kafka: `docker compose up -d`
+   - Run the app locally: `dotnet run`
+   - Iteratively build and validate your skill on `localhost:9092` before submitting your skill JSON to the central bus.
+3. **Browser-Based Google Cloud Shell**:
+   - Open [shell.cloud.google.com](https://shell.cloud.google.com) to run `gcloud` and test Kafka topics directly from inside Google Cloud.
+
+---
+
+#### Option B: Tailscale Subnet Router (For Direct Kafka TCP Access)
+
+If you need your local code to connect directly to the Managed Kafka TCP broker (`10.0.0.0/24`):
+
+1. **Install Tailscale**: Download from [tailscale.com/download](https://tailscale.com/download).
+2. **Join with Auth Key (Fastest — No Google Login)**:
    ```bash
-   gcloud compute ssh som-tailscale-router --tunnel-through-iap --project <project_id> --zone <zone>
+   tailscale up --authkey=<OBTAIN_KEY_FROM_ORGANIZER> --accept-routes
    ```
-2. Run `sudo tailscale up --advertise-routes=10.0.0.0/24` and follow the printed URL to authenticate.
-3. In your **Tailscale Admin Console**:
-   - Locate the `som-tailscale-router` device.
-   - Go to **Route settings** (under the meatball menu next to the device).
-   - Enable the advertised route `10.0.0.0/24`.
-   - Optionally disable key expiry on this device so it doesn't disconnect.
+3. **Shared Account Access (Fallback)**:
+   - If your organization requires joining via the shared Tailscale account, request access credentials directly from the hackathon organizers. *(Note: Credentials are never committed to git or GitHub).*
 
-#### 2. Developer Laptop Configuration
-Each developer who needs to connect from their local machine must do the following:
-
-1. **Install Tailscale**: Download and install Tailscale from [tailscale.com](https://tailscale.com).
-2. **Join the Tailnet**: Log in to the same Tailscale network used by the project.
-3. **Accept Subnet Routes**:
-   - **macOS / Windows**: Open Tailscale settings and ensure **Use Subnet Routes** (or "Accept Subnet Routes") is toggled ON.
-   - **Linux**: Run `sudo tailscale up --accept-routes`.
-4. **Authenticate with GCP (ADC)**:
-   Ensure you have the GCP SDK installed, then run:
+4. **Run the Application locally against Managed Kafka**:
    ```bash
-   gcloud auth login
    gcloud auth application-default login
-   ```
-   *Note: Your GCP user account must be granted the `roles/managedkafka.client` role in the GCP project to authenticate with Kafka.*
-5. **Run the Application**:
-   Configure the application to use the GCP Managed Kafka bootstrap server (find the actual URL in your terraform outputs or ask the administrator):
-   ```bash
-   export Kafka__BootstrapServers="bootstrap.som-kafka-cluster.[...].managedkafka.[...].cloud.goog:9092"
+
+   export Kafka__BootstrapServers="bootstrap.som-kafka-cluster.europe-west1.managedkafka.ibc-smart-stories.cloud.goog:9092"
    export Kafka__SecurityProtocol="SaslSsl"
    export Kafka__SaslMechanism="Plain"
-   export Kafka__SaslUsername="YOUR_GCP_EMAIL@example.com" # must match the ADC login identity
-   
+   export Kafka__SaslUsername="your-email@domain.com"
+
    dotnet run
    ```
 

--- a/som-hackathon-starter-dotnet/terraform/.terraform.lock.hcl
+++ b/som-hackathon-starter-dotnet/terraform/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/google" {
   version = "7.32.0"
   hashes = [
+    "h1:hDMENgq6nxoM6ttxN1HNrqbYiyRV8avLmUuUe4QWvKY=",
     "h1:izatO4h5Akqy4v1bha4w9FQmmCueZYwN3+hr9n5ZBW8=",
     "zh:091afeeeb58035f26ebaec34755a15d56e3229c4ce6db2745c52ba2593204a30",
     "zh:15d6a375c49d023dd21e612610b12bf79fbc6459bc5ad64b989d2180e9931f7d",

--- a/som-hackathon-starter-dotnet/terraform/main.tf
+++ b/som-hackathon-starter-dotnet/terraform/main.tf
@@ -29,6 +29,18 @@ resource "google_project_service" "artifactregistry" {
   disable_on_destroy = false
 }
 
+resource "google_project_service" "dns" {
+  service            = "dns.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudbuild" {
+  service            = "cloudbuild.googleapis.com"
+  disable_on_destroy = false
+}
+
+
+
 
 # Networking
 resource "google_compute_network" "vpc" {
@@ -339,6 +351,18 @@ resource "google_compute_instance" "tailscale_router" {
 }
 
 
+# Cloud DNS Inbound Policy for Split-DNS via Tailscale
+resource "google_dns_policy" "inbound_policy" {
+  name                      = "som-dns-inbound-policy"
+  enable_inbound_forwarding = true
+
+  networks {
+    network_url = google_compute_network.vpc.id
+  }
+
+  depends_on = [google_project_service.dns]
+}
+
 # TODO(security): Implement Identity-Aware Proxy (IAP) to restrict public access once developer identities are collected.
 resource "google_cloud_run_v2_service_iam_member" "public_access" {
   project  = var.project_id
@@ -347,3 +371,28 @@ resource "google_cloud_run_v2_service_iam_member" "public_access" {
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
+
+# Cloud Build Trigger for automatic deployment when changes land in som-hackathon-starter-dotnet
+resource "google_cloudbuild_trigger" "som_worker_trigger" {
+  name        = "som-skill-worker-trigger"
+  location    = var.region
+  description = "Trigger builds and deploys when changes land in som-hackathon-starter-dotnet"
+
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/github-connection/repositories/google-virtual-broadcast-production-assistant"
+
+    push {
+      branch = "^main$"
+    }
+  }
+
+  included_files  = ["som-hackathon-starter-dotnet/**"]
+  filename        = "som-hackathon-starter-dotnet/cloudbuild.yaml"
+  service_account = google_service_account.cloudbuild_sa.id
+
+  depends_on = [
+    google_project_service.cloudbuild
+  ]
+}
+
+

--- a/som-hackathon-starter-dotnet/terraform/terraform.tfvars.example
+++ b/som-hackathon-starter-dotnet/terraform/terraform.tfvars.example
@@ -5,3 +5,5 @@ image_url    = "us-central1-docker.pkg.dev/your-project-id/som-repo/som-skill-wo
 repository_name = "som-repo"
 kafka_bootstrap_servers = "host:port"
 cloudbuild_bucket = "som-infra-examples_cloudbuild"
+tailscale_auth_key = "tskey-auth-XXXXX"
+


### PR DESCRIPTION
- Add Cloud DNS Inbound Policy (som-dns-inbound-policy) to terraform/main.tf to enable split-DNS resolution for Managed Kafka *.cloud.goog hostnames via Tailscale.
- Fix Cloud Build trigger (som-skill-worker-trigger) path filter from som-hackathon-starter-dot-net/** to som-hackathon-starter-dotnet/** in terraform/main.tf.
- Update terraform.tfvars.example to document tailscale_auth_key.
- Update README.md to document low-friction Tailscale auth key quick start and zero-VPN corporate testing options via Cloud Run REST API and local Docker.