### PR TITLE
Add HyperContent SOM integration (skills + vendor capability)

### DIFF
--- a/hypercontent/README.md
+++ b/hypercontent/README.md
@@ -1,0 +1,40 @@
+# HyperContent — SOM integration
+
+HyperContent is a content-personalization layer for publishers. On the Story Object Model bus it
+plays two roles, contributed here as a vendor:
+
+## Tier 2 — declarative skills (run in the reference engine)
+
+Two skills authored in the reference rule-engine format live in
+[`../som-hackathon-starter-dotnet/skills/`](../som-hackathon-starter-dotnet/skills/) and fire in
+the starter with no code:
+
+- **`hypercontent-gate-treatment-by-sensitivity.json`** — a safety gate. When a story's subject is
+  sensitive, it raises `skill.warning.raised` (`severity: hold`) so a children's edition or a
+  gamified/"exciting" reel of a grave story is held for standards review. It gates on the
+  *audience × treatment*, never the story: a serious subject is fully reportable for a general
+  audience.
+- **`hypercontent-flag-on-omission.json`** — raises `skill.warning.raised` (`severity: flag`) when a
+  figure or claim risks losing its required caveat/attribution as it is reshaped into a smaller
+  format.
+
+## Tier 3 — HyperContent's own agent (method stays in HC infrastructure)
+
+Two capabilities run as HyperContent's own executor against `story.context` and publish
+`skill.suggestion.created` — the skill *declares*; the method runs in HC infrastructure (as AP's
+skills do). The declarations are in [`skills/`](skills/):
+
+- **`reshape-per-path`** — one story → a *Telling* per outlet/path (article, brief, explainer, …),
+  each a recombination of the story's own facts.
+- **`atomise-and-bond`** — the story's **fact-graph**: atoms (facts + source attribution) linked by
+  `must-travel-with` **bonds**, so a required caveat cannot be dropped from any derived telling
+  (e.g. an unverified casualty figure is bonded to its "not independently verified" caveat).
+
+## What is not here
+
+HyperContent's atomization taxonomy, bond-derivation, and reshaping models are the vendor's method
+and run in HyperContent's own executor and API — only the skill declarations and the on-wire
+message shapes appear in this repository, mirroring the vendor-capability model the standard
+describes.
+
+*Contributed by HyperContent to the IBC Smart Stories accelerator.*

--- a/hypercontent/README.md
+++ b/hypercontent/README.md
@@ -20,15 +20,23 @@ the starter with no code:
 
 ## Tier 3 — HyperContent's own agent (method stays in HC infrastructure)
 
-Two capabilities run as HyperContent's own executor against `story.context` and publish
-`skill.suggestion.created` — the skill *declares*; the method runs in HC infrastructure (as AP's
-skills do). The declarations are in [`skills/`](skills/):
+Two capabilities run as HyperContent's own external executor (an `external Kafka consumer/publisher`,
+exactly like AP's wire-fact-check): the executor is never invoked over HTTP — it self-subscribes to
+`som.story.context`, runs the method in HC infrastructure, and publishes `skill.suggestion.created`
+to `som.skills.staging` plus a `skill.run.completed` audit to `som.skills.runs`. The skill JSON is a
+**registration-only** dashboard stub (advert + non-firing sentinel rule) that keeps the capability
+visible and governable and declares the `produces[]` the bus admits. The registration stubs live
+alongside the reference dashboard's skills at
+[`../som-hackathon-starter-dotnet/skills/`](../som-hackathon-starter-dotnet/skills/):
 
-- **`reshape-per-path`** — one story → a *Telling* per outlet/path (article, brief, explainer, …),
-  each a recombination of the story's own facts.
-- **`atomise-and-bond`** — the story's **fact-graph**: atoms (facts + source attribution) linked by
-  `must-travel-with` **bonds**, so a required caveat cannot be dropped from any derived telling
-  (e.g. an unverified casualty figure is bonded to its "not independently verified" caveat).
+- **`hypercontent-reshape-per-path.json`** — one story → a *Telling* per outlet/path (article, brief,
+  explainer, …), each a recombination of the story's own facts.
+- **`hypercontent-atomise-and-bond.json`** — the story's **fact-graph**: atoms (facts + source
+  attribution) linked by `must-travel-with` **bonds**, so a required caveat cannot be dropped from any
+  derived telling (e.g. an unverified casualty figure is bonded to its "not independently verified"
+  caveat).
+
+The human-readable capability notes are in [`skills/`](skills/) (`*.SKILL.md`).
 
 ## What is not here
 

--- a/hypercontent/README.md
+++ b/hypercontent/README.md
@@ -10,10 +10,11 @@ Two skills authored in the reference rule-engine format live in
 the starter with no code:
 
 - **`hypercontent-gate-treatment-by-sensitivity.json`** — a safety gate. When a story's subject is
-  sensitive, it raises `skill.warning.raised` (`severity: hold`) so a children's edition or a
-  gamified/"exciting" reel of a grave story is held for standards review. It gates on the
-  *audience × treatment*, never the story: a serious subject is fully reportable for a general
-  audience.
+  sensitive, it raises `skill.warning.raised` (`severity: hold`) that routes a children's edition or
+  a gamified/"exciting" reel of a grave story to standards review before it is composed. The `hold`
+  is a label the bus carries, not automatic suppression: the human approval gate holds the telling
+  and the executor withholds it on that decision. It gates on the *audience × treatment*, never the
+  story: a serious subject is fully reportable for a general audience.
 - **`hypercontent-flag-on-omission.json`** — raises `skill.warning.raised` (`severity: flag`) when a
   figure or claim risks losing its required caveat/attribution as it is reshaped into a smaller
   format.

--- a/hypercontent/skills/atomise-and-bond.SKILL.md
+++ b/hypercontent/skills/atomise-and-bond.SKILL.md
@@ -1,0 +1,77 @@
+---
+name: atomise-and-bond
+desk: standards
+triggers:
+  - "atomize"
+  - "fact graph"
+  - "extract atoms"
+  - "verification bonds"
+requires_review: standards
+confidence_threshold: 0.85
+owners:
+  editorial: standards@hypercontent.ai
+  engineering: som-eng@hypercontent.ai
+version: 0.2.0
+som_schema_version: "0.3"
+skill_priority: standard
+som:
+  subscribes:
+    - story.lifecycle.changed
+    - story.premise.updated
+    - story.enrichment.added
+  publishes:
+    - skill.suggestion.created
+  reads:
+    - headline
+    - premise
+    - story_meaning
+    - sources
+    - content_refs
+  writes:
+    - suggestions
+  scope:
+    shows: []
+    desks: []
+  migration: cold
+  tools:
+    - atomise_and_bond
+---
+
+# Atomise & Bond
+
+Authored by HyperContent for the Smart Stories skills library. Public attribution requested —
+credit HyperContent as author.
+
+**Tier 3 (autonomous agent).** HyperContent's core capability: it decomposes a story into a
+**fact-graph** — an ordered set of **atoms** (single factual claims, each carrying its source
+attribution) linked by **bonds**. A bond of kind `must-travel-with` ties a fact to the caveat it
+cannot be shown without: an unverified casualty figure is bonded to its *"not independently
+verified"* caveat, so any downstream telling (a reel, a brief, a children's edition) that keeps the
+figure **structurally cannot drop the caveat**. The fact-graph is the substrate the reach and
+governance skills stand on — `reshape-per-path` recombines atoms (never inventing facts), and
+`flag-on-omission` / `gate-treatment-by-sensitivity` are enforceable *because* the required
+companions are bonded, not merely hoped for.
+
+## What it produces
+
+A story enrichment published as `skill.suggestion.created` (a producer accepts it into the story
+context), carrying:
+
+- **atoms** — `{ id, text, source_ref, span, required }`. `source_ref` is who the claim is
+  attributed to; `span` locates it in the source; `required: true` marks a claim that must not be
+  dropped from any telling.
+- **bonds** — `{ from, to, kind }`, where `kind: "must-travel-with"` means the `to` atom (a caveat,
+  attribution, or qualifier) must accompany the `from` atom in every derived telling.
+
+## What stays private
+
+Only the fact-graph *shape* above goes on the wire. **How** atoms are typed and **how** bonds are
+derived — HyperContent's atom taxonomy, the bond-derivation model, the prompts — live entirely in
+the agent ([`../../agent/`](../../agent/), tool `atomise_and_bond` → HyperContent's
+`/v1/som/atomize`) and never appear in the skill or on the bus. The skill advertises the capability;
+the method is HyperContent's.
+
+## Escalation
+
+Atoms marked `required` and every `must-travel-with` bond are surfaced to the standards desk as the
+non-droppable core of the story. Verified end-to-end against the SOM reference implementation.

--- a/hypercontent/skills/atomise-and-bond.SKILL.md
+++ b/hypercontent/skills/atomise-and-bond.SKILL.md
@@ -12,20 +12,18 @@ owners:
   editorial: standards@hypercontent.ai
   engineering: som-eng@hypercontent.ai
 version: 0.2.0
-som_schema_version: "0.3"
+som_schema_version: "0.3.2"
 skill_priority: standard
 som:
   subscribes:
-    - story.lifecycle.changed
-    - story.premise.updated
-    - story.enrichment.added
+    - story.context
   publishes:
     - skill.suggestion.created
   reads:
     - headline
     - premise
     - story_meaning
-    - sources
+    - editorial_source
     - content_refs
   writes:
     - suggestions

--- a/hypercontent/skills/reshape-per-path.SKILL.md
+++ b/hypercontent/skills/reshape-per-path.SKILL.md
@@ -1,0 +1,89 @@
+---
+name: reshape-per-path
+desk: distribution
+triggers:
+  - "publish"
+  - "editorial gate cleared"
+  - "reshape for path"
+  - "render per outlet"
+requires_review: none
+confidence_threshold: 0.80
+owners:
+  editorial: standards@hypercontent.ai
+  engineering: som-eng@hypercontent.ai
+version: 0.2.0
+som_schema_version: "0.3"
+skill_priority: standard
+som:
+  subscribes:
+    - story.lifecycle.changed
+    - story.editorial.updated
+    - story.assets.updated
+  publishes:
+    - skill.suggestion.created
+  reads:
+    - premise
+    - sources
+    - editorial_gates
+    - planning
+    - assets
+    - content_refs
+  writes:
+    - suggestions
+  scope:
+    shows: []
+    desks: []
+    lifecycle_phases: []
+  migration: cold
+  tools:
+    - render_telling
+---
+
+# Reshape per Path
+
+Contributed by HyperContent to the Smart Stories skills library. Public attribution requested —
+credit HyperContent as author.
+
+**Tier 3 (autonomous agent), not a Tier-2 rule.** Reshaping is generative, so it isn't a
+declarative rule dropped into the reference rule engine — it runs as HyperContent's own agent
+(`../../agent/som_reshape_agent.py`): consume `story.context` → reshape into a Telling per
+outlet/path → publish `skill.suggestion.created` to `som.skills.staging` for the editorial gate.
+This SKILL.md is the advert; the method lives in the agent, not on the wire — exactly as a vendor
+capability skill should. Verified end-to-end against the SOM reference implementation.
+
+## When this applies
+
+Activate when a story's editorial gate clears for a destination path — the same publish decision
+Beat 5 already carries. In SOM v0.3 terms, each destination path is an **outlet**, and rendering a
+story's asset for that outlet produces a **Telling** (the runtime cross-point where an Asset meets
+an Outlet). The firing key is *asset category × outlet/path*: the same cleared story fans out into
+one Telling per path.
+
+## What to produce
+
+For each destination path whose gate is `clear`, produce one Telling in that path's native format —
+an article page, a feed card, a vertical video, a newsletter item, an audience edition. Emit a
+single `skill.suggestion.created` carrying one variant per `(path, format)`. Each variant stages
+`PENDING` on `som.skills.staging` for the gate; a human accepts, rejects, or modifies it, which the
+bus records as `skill.suggestion.resolved`. The executor proposes; it never applies.
+
+## Hard rules
+
+- **Reshape, never generate.** Every Telling is a recombination of the story's *own* elements
+  (`premise`, `sources`, and the body fetched from `content_refs[].uri`). A Telling must not
+  introduce a fact that is not already in the story.
+- **Held facts never render.** A fact held by its editorial gate (or by a `hold`-severity
+  `skill.warning.raised` from another skill) MUST NOT appear in any Telling, in any format.
+- **One publish event, every format.** Format decisions ride the same story state as the publish
+  decision — no second gate, no divergent copy per path.
+
+## Escalation
+
+If a path's gate state is ambiguous, or a required element is held with no cleared alternative, do
+not render that path's Telling; leave it for the producer. Absence of an expected Telling is
+observable (see `flag-on-omission`), so nothing is dropped silently.
+
+## Pairs with
+
+- `flag-on-omission` — guards that each rendered Telling keeps its required elements.
+- `gate-treatment-by-sensitivity` — constrains which outlets/audiences may be rendered at all.

--- a/hypercontent/skills/reshape-per-path.SKILL.md
+++ b/hypercontent/skills/reshape-per-path.SKILL.md
@@ -12,20 +12,18 @@ owners:
   editorial: standards@hypercontent.ai
   engineering: som-eng@hypercontent.ai
 version: 0.2.0
-som_schema_version: "0.3"
+som_schema_version: "0.3.2"
 skill_priority: standard
 som:
   subscribes:
-    - story.lifecycle.changed
-    - story.editorial.updated
-    - story.assets.updated
+    - story.context
   publishes:
     - skill.suggestion.created
   reads:
     - premise
-    - sources
+    - editorial_source
     - editorial_gates
-    - planning
+    - extensions
     - assets
     - content_refs
   writes:

--- a/som-hackathon-starter-dotnet/skills/hypercontent-atomise-and-bond.json
+++ b/som-hackathon-starter-dotnet/skills/hypercontent-atomise-and-bond.json
@@ -1,0 +1,89 @@
+{
+  "id": "hypercontent/atomise-and-bond",
+  "version": "0.2.0",
+  "name": "HyperContent Atomise and Bond",
+  "description": "Dashboard registration for HyperContent's atomise-and-bond skill. The production skill consumes story.context, breaks the story into atoms (facts + source attribution) and derives must-travel-with bonds between them (e.g. an unverified casualty figure bonded to its 'not independently verified' caveat), then publishes the fact-graph as flat skill.suggestion.created outputs to som.skills.staging plus skill.run.completed audit records to som.skills.runs. A bonded caveat cannot be dropped from any derived telling. This JSON keeps the skill visible and governable in the dashboard; real processing runs in HyperContent's own executor (external Kafka consumer/publisher).",
+  "skill_type": "vendor",
+  "disclosure_level": "L1",
+  "migration_policy": "cold",
+  "reads": [
+    "story_id",
+    "headline",
+    "story_meaning",
+    "story_meaning.provenance_refs",
+    "content_refs[].uri",
+    "content_refs[].content_format"
+  ],
+  "produces": [
+    "skill.suggestion.created",
+    "skill.run.completed"
+  ],
+  "advert": {
+    "role": "the story's fact-graph: atoms + must-travel-with bonds so a required caveat cannot be dropped",
+    "operates_on": ["story.context"],
+    "produces": ["skill.suggestion.created", "skill.run.completed"],
+    "target_system_types": ["content_composition", "automation"],
+    "fires_on": ["headline", "story_meaning"]
+  },
+  "runtime": {
+    "owner": "HyperContent",
+    "executor_id": "hypercontent-atomise-agent-01",
+    "system_type": "content_composition",
+    "deployment_region": "us-east-1",
+    "deployment_name": "HyperContent SOM atomise agent",
+    "execution_model": "external Kafka consumer/publisher",
+    "dashboard_file_purpose": "registration_only"
+  },
+  "kafka": {
+    "consumes": ["som.story.context"],
+    "publishes": {
+      "approval_staging": "som.skills.staging",
+      "run_audit": "som.skills.runs"
+    },
+    "approval_flow": "DashboardService approves staged suggestions and republishes accepted items to som.skills.events."
+  },
+  "output_contracts": [
+    {
+      "message_type": "skill.suggestion.created",
+      "topic": "som.skills.staging",
+      "shape": "flat_som_v0_2_dashboard_compatible",
+      "id_field": "suggestion_id",
+      "required_top_level_fields": [
+        "som_version", "message_id", "message_type", "timestamp", "source",
+        "suggestion_id", "skill_id", "skill_version", "story_id", "story_version",
+        "scope", "suggestion_type", "confidence", "content_type", "output",
+        "tools_invoked", "disclosure_levels_used", "context_snapshot"
+      ],
+      "notes": "output carries atoms[] and bonds[] (bond_type must-travel-with); a derived telling cannot drop a bonded caveat."
+    },
+    {
+      "message_type": "skill.run.completed",
+      "topic": "som.skills.runs",
+      "shape": "flat_som_v0_2_dashboard_compatible",
+      "id_field": "run_id",
+      "required_top_level_fields": [
+        "som_version", "message_id", "message_type", "timestamp", "source",
+        "run_id", "skill_id", "skill_version", "story_id", "story_version",
+        "triggered_by", "inputs", "outputs", "latency_ms", "outcome"
+      ],
+      "outcome_enum": ["COMPLETED", "FAILED", "SKIPPED", "CONFLICTED"],
+      "outputs_fields": ["warning_ids", "suggestion_ids", "enrichment_ids"]
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "hypercontent-atomise-and-bond-registration-only",
+      "name": "Registration sentinel",
+      "description": "Non-firing sentinel rule. Atomise-and-bond execution is handled by HyperContent's own external executor, not by this dashboard rule engine.",
+      "type": "field_present",
+      "config": {
+        "field": "extensions.com.hypercontent.registration_only_force_atomise"
+      },
+      "default_severity": "inform",
+      "output_message_type": "skill.warning.raised",
+      "affected_fields": ["headline", "story_meaning", "story_meaning.provenance_refs"],
+      "detail_template": "HyperContent Atomise and Bond registration sentinel fired. Real processing should be performed by HyperContent's external skill worker.",
+      "rationale": "This file registers HyperContent's real external skill with the dashboard. The sentinel should not fire on normal SOM stories."
+    }
+  ]
+}

--- a/som-hackathon-starter-dotnet/skills/hypercontent-atomise-and-bond.json
+++ b/som-hackathon-starter-dotnet/skills/hypercontent-atomise-and-bond.json
@@ -3,9 +3,9 @@
   "version": "0.2.0",
   "name": "HyperContent Atomise and Bond",
   "description": "Dashboard registration for HyperContent's atomise-and-bond skill. The production skill consumes story.context, breaks the story into atoms (facts + source attribution) and derives must-travel-with bonds between them (e.g. an unverified casualty figure bonded to its 'not independently verified' caveat), then publishes the fact-graph as flat skill.suggestion.created outputs to som.skills.staging plus skill.run.completed audit records to som.skills.runs. A bonded caveat cannot be dropped from any derived telling. This JSON keeps the skill visible and governable in the dashboard; real processing runs in HyperContent's own executor (external Kafka consumer/publisher).",
-  "skill_type": "vendor",
+  "skill_type": "VENDOR",
   "disclosure_level": "L1",
-  "migration_policy": "cold",
+  "migration_policy": "COLD",
   "reads": [
     "story_id",
     "headline",

--- a/som-hackathon-starter-dotnet/skills/hypercontent-flag-on-omission.json
+++ b/som-hackathon-starter-dotnet/skills/hypercontent-flag-on-omission.json
@@ -1,0 +1,57 @@
+{
+  "id": "hypercontent/flag-on-omission",
+  "version": "0.2.0",
+  "name": "Flag on Omission",
+  "description": "Authored by HyperContent. A reshaped format is a smaller surface than the original, so the risk is that a required element is lost in the reshaping — a figure without its caveat, a claim without its attribution. This skill flags stories carrying an unqualified figure or a claim with no provenance, so the executor keeps the required companion travelling with the element in every derived telling. Flag, never rewrite: a human makes the call.",
+  "skill_type": "NEWSROOM",
+  "disclosure_level": "L2",
+  "migration_policy": "COLD",
+  "reads": [
+    "story_meaning.summary",
+    "story_meaning.provenance_refs",
+    "compliance"
+  ],
+  "produces": [
+    "skill.warning.raised",
+    "skill.run.completed"
+  ],
+  "advert": {
+    "role": "required-element coverage guard for derived formats",
+    "operates_on": ["story.context"],
+    "produces": ["skill.warning.raised", "skill.run.completed"],
+    "target_system_types": ["content_composition", "automation"],
+    "fires_on": ["story_meaning"]
+  },
+  "rules": [
+    {
+      "rule_id": "hc-omission-unqualified-figure",
+      "name": "Figure present — required caveat must travel with it",
+      "description": "A hard number in the story meaning (casualty count, category, magnitude) must keep its verification caveat and attribution in every reshaped telling.",
+      "type": "field_regex",
+      "config": {
+        "field": "story_meaning.summary",
+        "pattern": "(Category\\s*\\d+|Magnitude\\s*\\d|\\b\\d[\\d,]*\\s*(dead|killed|injured|wounded|missing|fatalities|casualties|people|homes)\\b)",
+        "case_sensitive": false
+      },
+      "default_severity": "flag",
+      "output_message_type": "skill.warning.raised",
+      "affected_fields": ["story_meaning.summary"],
+      "detail_template": "The story carries a figure ('{match}'). Ensure its verification caveat and attribution travel with it in every derived telling — a feed card or a reel must not show the number alone.",
+      "rationale": "In a shorter format the caveat is the first thing dropped. This flags the figure so the required companion is preserved through reshaping. Flag, not hold — the editor decides."
+    },
+    {
+      "rule_id": "hc-omission-no-provenance",
+      "name": "Claim with no provenance",
+      "description": "A story whose meaning carries no provenance references cannot have its sourcing preserved through reshaping; flag it before any derived telling is built.",
+      "type": "field_absent",
+      "config": {
+        "field": "story_meaning.provenance_refs"
+      },
+      "default_severity": "flag",
+      "output_message_type": "skill.warning.raised",
+      "affected_fields": ["story_meaning.provenance_refs"],
+      "detail_template": "No provenance references on the story meaning. A derived telling cannot preserve sourcing that isn't there — attach provenance before reshaping.",
+      "rationale": "Omission guard: what a telling must not drop. Fires only when provenance is genuinely absent, so a well-sourced story stays silent."
+    }
+  ]
+}

--- a/som-hackathon-starter-dotnet/skills/hypercontent-flag-on-omission.json
+++ b/som-hackathon-starter-dotnet/skills/hypercontent-flag-on-omission.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "name": "Flag on Omission",
   "description": "Authored by HyperContent. A reshaped format is a smaller surface than the original, so the risk is that a required element is lost in the reshaping — a figure without its caveat, a claim without its attribution. This skill flags stories carrying an unqualified figure or a claim with no provenance, so the executor keeps the required companion travelling with the element in every derived telling. Flag, never rewrite: a human makes the call.",
-  "skill_type": "NEWSROOM",
+  "skill_type": "VENDOR",
   "disclosure_level": "L2",
   "migration_policy": "COLD",
   "reads": [

--- a/som-hackathon-starter-dotnet/skills/hypercontent-gate-treatment-by-sensitivity.json
+++ b/som-hackathon-starter-dotnet/skills/hypercontent-gate-treatment-by-sensitivity.json
@@ -1,0 +1,62 @@
+{
+  "id": "hypercontent/gate-treatment-by-sensitivity",
+  "version": "0.2.0",
+  "name": "Gate Treatment by Sensitivity",
+  "description": "Authored by HyperContent. A safety gate on any reshaping / reach step. When a story's subject is sensitive, some audience editions and some treatments are incompatible and must not be produced — no children's edition of an atrocity, no gamified/'exciting' vertical reel of a mass-casualty event, no upbeat framing of a disaster. The skill declares; the executor holds those tellings for standards review before they are composed and renders the rest in a sober register. Nothing about the story changes — only which tellings are allowed. Backed by HyperContent's shipped sensitivity policy.",
+  "skill_type": "NEWSROOM",
+  "disclosure_level": "L2",
+  "migration_policy": "COLD",
+  "reads": [
+    "headline",
+    "story_meaning.summary",
+    "story_meaning.what",
+    "lifecycle.phase",
+    "compliance",
+    "planning"
+  ],
+  "produces": [
+    "skill.warning.raised",
+    "skill.run.completed"
+  ],
+  "advert": {
+    "role": "audience/treatment safety gate for derived formats",
+    "operates_on": ["story.context"],
+    "produces": ["skill.warning.raised", "skill.run.completed"],
+    "target_system_types": ["content_composition", "automation"],
+    "fires_on": ["headline", "story_meaning", "compliance"]
+  },
+  "rules": [
+    {
+      "rule_id": "hc-sensitivity-conflict",
+      "name": "Sensitive subject — armed conflict / violence / disaster",
+      "description": "Detects a grave subject in the headline that makes a children's edition or a gamified/'exciting' reel treatment incompatible.",
+      "type": "term_match",
+      "config": {
+        "field": "headline",
+        "terms": ["war", "conflict", "airstrike", "air strike", "shelling", "attack", "terror", "shooting", "gunman", "weapon", "explosion", "bomb", "casualties", "killed", "dead", "massacre", "hostage", "assault", "abuse", "hurricane", "landfall", "earthquake", "flood", "wildfire", "disaster", "evacuat", "overdose", "narcotics", "suicide", "self-harm"],
+        "case_sensitive": false
+      },
+      "default_severity": "hold",
+      "output_message_type": "skill.warning.raised",
+      "affected_fields": ["planning.audiences", "planning.paths"],
+      "detail_template": "Sensitive subject ('{term}') in the headline. A children's edition or a gamified/'exciting' vertical reel of this story must NOT be produced; hold those tellings for standards review and compose the rest in a sober register.",
+      "rationale": "HyperContent's sensitivity policy gates on the audience × treatment, not the subject: the story is fully reportable for a general audience, but specific incompatible tellings (children's edition, gamified reel, upbeat framing) are held. Deterministic over the declared/observed subject."
+    },
+    {
+      "rule_id": "hc-sensitivity-summary",
+      "name": "Sensitive subject — in the story meaning",
+      "description": "Second pass over the human-written story_meaning summary, which often carries the grave detail (distressing imagery, rescue, victims) even when the headline is neutral.",
+      "type": "term_match",
+      "config": {
+        "field": "story_meaning.summary",
+        "terms": ["distressing", "graphic", "casualties", "victims", "fatalities", "rescue", "bodies", "wounded", "atrocity", "abuse", "self-harm", "suicide", "overdose", "children killed", "minors"],
+        "case_sensitive": false
+      },
+      "default_severity": "hold",
+      "output_message_type": "skill.warning.raised",
+      "affected_fields": ["planning.audiences", "planning.paths"],
+      "detail_template": "Story meaning notes sensitive content ('{term}'). Hold any children's-audience or gamified/reel telling for standards review; the general-audience telling proceeds in a sober register.",
+      "rationale": "The subject often lives in the editor-written story_meaning rather than the headline. Same gate: block the incompatible audience × treatment, never the story."
+    }
+  ]
+}

--- a/som-hackathon-starter-dotnet/skills/hypercontent-gate-treatment-by-sensitivity.json
+++ b/som-hackathon-starter-dotnet/skills/hypercontent-gate-treatment-by-sensitivity.json
@@ -2,8 +2,8 @@
   "id": "hypercontent/gate-treatment-by-sensitivity",
   "version": "0.2.0",
   "name": "Gate Treatment by Sensitivity",
-  "description": "Authored by HyperContent. A safety gate on any reshaping / reach step. When a story's subject is sensitive, some audience editions and some treatments are incompatible and must not be produced — no children's edition of an atrocity, no gamified/'exciting' vertical reel of a mass-casualty event, no upbeat framing of a disaster. The skill declares; the executor holds those tellings for standards review before they are composed and renders the rest in a sober register. Nothing about the story changes — only which tellings are allowed. Backed by HyperContent's shipped sensitivity policy.",
-  "skill_type": "NEWSROOM",
+  "description": "Authored by HyperContent. A safety gate on any reshaping / reach step. When a story's subject is sensitive, some audience editions and some treatments are incompatible and must not be produced — no children's edition of an atrocity, no gamified/'exciting' vertical reel of a mass-casualty event, no upbeat framing of a disaster. The skill declares a hold-severity warning; the human standards gate routes those tellings for review before they are composed, and the rest render in a sober register. The bus carries the warning as a label — it does not itself suppress output; enforcement is the executor's, gated on the standards review. Nothing about the story changes — only which tellings are allowed. Backed by HyperContent's shipped sensitivity policy.",
+  "skill_type": "VENDOR",
   "disclosure_level": "L2",
   "migration_policy": "COLD",
   "reads": [
@@ -12,7 +12,8 @@
     "story_meaning.what",
     "lifecycle.phase",
     "compliance",
-    "planning"
+    "extensions.com.hypercontent.audiences",
+    "extensions.com.hypercontent.paths"
   ],
   "produces": [
     "skill.warning.raised",
@@ -33,28 +34,28 @@
       "type": "term_match",
       "config": {
         "field": "headline",
-        "terms": ["war", "conflict", "airstrike", "air strike", "shelling", "attack", "terror", "shooting", "gunman", "weapon", "explosion", "bomb", "casualties", "killed", "dead", "massacre", "hostage", "assault", "abuse", "hurricane", "landfall", "earthquake", "flood", "wildfire", "disaster", "evacuat", "overdose", "narcotics", "suicide", "self-harm"],
+        "terms": ["war", "conflict", "airstrike", "air strike", "shelling", "attack", "terror", "shooting", "gunman", "weapon", "explosion", "bomb", "casualties", "killed", "dead", "massacre", "hostage", "assault", "abuse", "disaster", "evacuat", "overdose", "narcotics", "suicide", "self-harm"],
         "case_sensitive": false
       },
       "default_severity": "hold",
       "output_message_type": "skill.warning.raised",
-      "affected_fields": ["planning.audiences", "planning.paths"],
+      "affected_fields": ["extensions.com.hypercontent.audiences", "extensions.com.hypercontent.paths"],
       "detail_template": "Sensitive subject ('{term}') in the headline. A children's edition or a gamified/'exciting' vertical reel of this story must NOT be produced; hold those tellings for standards review and compose the rest in a sober register.",
       "rationale": "HyperContent's sensitivity policy gates on the audience × treatment, not the subject: the story is fully reportable for a general audience, but specific incompatible tellings (children's edition, gamified reel, upbeat framing) are held. Deterministic over the declared/observed subject."
     },
     {
       "rule_id": "hc-sensitivity-summary",
       "name": "Sensitive subject — in the story meaning",
-      "description": "Second pass over the human-written story_meaning summary, which often carries the grave detail (distressing imagery, rescue, victims) even when the headline is neutral.",
+      "description": "Second pass over the human-written story_meaning summary, which often carries the grave detail (distressing imagery, victims) even when the headline is neutral. Terms are whole words or phrases (e.g. 'graphic imagery', not bare 'graphic') so ordinary vocabulary like a 'graphics package' does not trip the gate.",
       "type": "term_match",
       "config": {
         "field": "story_meaning.summary",
-        "terms": ["distressing", "graphic", "casualties", "victims", "fatalities", "rescue", "bodies", "wounded", "atrocity", "abuse", "self-harm", "suicide", "overdose", "children killed", "minors"],
+        "terms": ["distressing", "graphic imagery", "graphic content", "casualties", "victims", "fatalities", "rescue", "bodies", "wounded", "atrocity", "abuse", "self-harm", "suicide", "overdose", "children killed"],
         "case_sensitive": false
       },
       "default_severity": "hold",
       "output_message_type": "skill.warning.raised",
-      "affected_fields": ["planning.audiences", "planning.paths"],
+      "affected_fields": ["extensions.com.hypercontent.audiences", "extensions.com.hypercontent.paths"],
       "detail_template": "Story meaning notes sensitive content ('{term}'). Hold any children's-audience or gamified/reel telling for standards review; the general-audience telling proceeds in a sober register.",
       "rationale": "The subject often lives in the editor-written story_meaning rather than the headline. Same gate: block the incompatible audience × treatment, never the story."
     }

--- a/som-hackathon-starter-dotnet/skills/hypercontent-reshape-per-path.json
+++ b/som-hackathon-starter-dotnet/skills/hypercontent-reshape-per-path.json
@@ -1,0 +1,90 @@
+{
+  "id": "hypercontent/reshape-per-path",
+  "version": "0.2.0",
+  "name": "HyperContent Reshape Per Path",
+  "description": "Dashboard registration for HyperContent's reshape-per-path skill. The production skill consumes story.context, and for each planned outlet/path (article, brief, explainer, reel, ...) recombines the story's OWN elements (headline + story_meaning) into a distinct Telling — never inventing facts — then publishes flat skill.suggestion.created outputs to som.skills.staging plus skill.run.completed audit records to som.skills.runs. This JSON keeps the skill visible and governable in the dashboard; real processing runs in HyperContent's own executor (external Kafka consumer/publisher).",
+  "skill_type": "vendor",
+  "disclosure_level": "L1",
+  "migration_policy": "cold",
+  "reads": [
+    "story_id",
+    "headline",
+    "story_meaning",
+    "planning.paths",
+    "content_refs[].uri",
+    "content_refs[].content_format"
+  ],
+  "produces": [
+    "skill.suggestion.created",
+    "skill.run.completed"
+  ],
+  "advert": {
+    "role": "one story -> a Telling per outlet/path, recombined from the story's own facts",
+    "operates_on": ["story.context"],
+    "produces": ["skill.suggestion.created", "skill.run.completed"],
+    "target_system_types": ["content_composition", "automation"],
+    "fires_on": ["headline", "story_meaning", "planning"]
+  },
+  "runtime": {
+    "owner": "HyperContent",
+    "executor_id": "hypercontent-reshape-agent-01",
+    "system_type": "content_composition",
+    "deployment_region": "us-east-1",
+    "deployment_name": "HyperContent SOM reshape agent",
+    "execution_model": "external Kafka consumer/publisher",
+    "dashboard_file_purpose": "registration_only"
+  },
+  "kafka": {
+    "consumes": ["som.story.context"],
+    "publishes": {
+      "approval_staging": "som.skills.staging",
+      "run_audit": "som.skills.runs"
+    },
+    "approval_flow": "DashboardService approves staged suggestions and republishes accepted items to som.skills.events."
+  },
+  "output_contracts": [
+    {
+      "message_type": "skill.suggestion.created",
+      "topic": "som.skills.staging",
+      "shape": "flat_som_v0_2_dashboard_compatible",
+      "id_field": "suggestion_id",
+      "required_top_level_fields": [
+        "som_version", "message_id", "message_type", "timestamp", "source",
+        "suggestion_id", "skill_id", "skill_version", "story_id", "story_version",
+        "scope", "suggestion_type", "confidence", "content_type", "variants",
+        "output", "tools_invoked", "disclosure_levels_used", "context_snapshot"
+      ],
+      "variant_fields": ["variant_id", "content_type", "format", "label", "confidence", "payload", "preview", "title", "detail"],
+      "notes": "One variant per outlet/path; each is a recombination of the story's own facts."
+    },
+    {
+      "message_type": "skill.run.completed",
+      "topic": "som.skills.runs",
+      "shape": "flat_som_v0_2_dashboard_compatible",
+      "id_field": "run_id",
+      "required_top_level_fields": [
+        "som_version", "message_id", "message_type", "timestamp", "source",
+        "run_id", "skill_id", "skill_version", "story_id", "story_version",
+        "triggered_by", "inputs", "outputs", "latency_ms", "outcome"
+      ],
+      "outcome_enum": ["COMPLETED", "FAILED", "SKIPPED", "CONFLICTED"],
+      "outputs_fields": ["warning_ids", "suggestion_ids", "enrichment_ids"]
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "hypercontent-reshape-per-path-registration-only",
+      "name": "Registration sentinel",
+      "description": "Non-firing sentinel rule. Reshape-per-path execution is handled by HyperContent's own external executor, not by this dashboard rule engine.",
+      "type": "field_present",
+      "config": {
+        "field": "extensions.com.hypercontent.registration_only_force_reshape"
+      },
+      "default_severity": "inform",
+      "output_message_type": "skill.warning.raised",
+      "affected_fields": ["headline", "story_meaning", "planning.paths"],
+      "detail_template": "HyperContent Reshape Per Path registration sentinel fired. Real processing should be performed by HyperContent's external skill worker.",
+      "rationale": "This file registers HyperContent's real external skill with the dashboard. The sentinel should not fire on normal SOM stories."
+    }
+  ]
+}

--- a/som-hackathon-starter-dotnet/skills/hypercontent-reshape-per-path.json
+++ b/som-hackathon-starter-dotnet/skills/hypercontent-reshape-per-path.json
@@ -3,14 +3,14 @@
   "version": "0.2.0",
   "name": "HyperContent Reshape Per Path",
   "description": "Dashboard registration for HyperContent's reshape-per-path skill. The production skill consumes story.context, and for each planned outlet/path (article, brief, explainer, reel, ...) recombines the story's OWN elements (headline + story_meaning) into a distinct Telling — never inventing facts — then publishes flat skill.suggestion.created outputs to som.skills.staging plus skill.run.completed audit records to som.skills.runs. This JSON keeps the skill visible and governable in the dashboard; real processing runs in HyperContent's own executor (external Kafka consumer/publisher).",
-  "skill_type": "vendor",
+  "skill_type": "VENDOR",
   "disclosure_level": "L1",
-  "migration_policy": "cold",
+  "migration_policy": "COLD",
   "reads": [
     "story_id",
     "headline",
     "story_meaning",
-    "planning.paths",
+    "extensions.com.hypercontent.paths",
     "content_refs[].uri",
     "content_refs[].content_format"
   ],
@@ -23,7 +23,7 @@
     "operates_on": ["story.context"],
     "produces": ["skill.suggestion.created", "skill.run.completed"],
     "target_system_types": ["content_composition", "automation"],
-    "fires_on": ["headline", "story_meaning", "planning"]
+    "fires_on": ["headline", "story_meaning", "extensions.com.hypercontent.paths"]
   },
   "runtime": {
     "owner": "HyperContent",
@@ -82,7 +82,7 @@
       },
       "default_severity": "inform",
       "output_message_type": "skill.warning.raised",
-      "affected_fields": ["headline", "story_meaning", "planning.paths"],
+      "affected_fields": ["headline", "story_meaning", "extensions.com.hypercontent.paths"],
       "detail_template": "HyperContent Reshape Per Path registration sentinel fired. Real processing should be performed by HyperContent's external skill worker.",
       "rationale": "This file registers HyperContent's real external skill with the dashboard. The sentinel should not fire on normal SOM stories."
     }


### PR DESCRIPTION
HyperContent joins as a vendor on the Story Object Model bus.

**Tier 2 — declarative skills (run in the reference rule engine):**
- `som-hackathon-starter-dotnet/skills/hypercontent-gate-treatment-by-sensitivity.json` — a safety gate that raises `skill.warning.raised` (severity: hold) so a children's edition or a gamified/"exciting" reel of a sensitive story is held for standards review. Gates on the audience × treatment, never the story.
- `som-hackathon-starter-dotnet/skills/hypercontent-flag-on-omission.json` — raises `skill.warning.raised` (severity: flag) when a figure/claim risks losing its required caveat or attribution as it is reshaped into a smaller format.

**Tier 3 — HyperContent's own executor (method stays in HC infrastructure):**
- `hypercontent/` — README + skill declarations for `reshape-per-path` (one story → a Telling per outlet/path) and `atomise-and-bond` (the story's fact-graph: atoms + must-travel-with bonds, so a required caveat cannot be dropped from a derived telling).

Only skill declarations and on-wire message shapes appear here; the atomization/reshaping method runs in HyperContent's own executor, mirroring the vendor-capability model (as AP's skills do).