### PR TITLE
SomHackathon: dashboard hardening — 3 bug fixes + DOM-XSS cleanup

### DIFF
--- a/som-hackathon-starter-dotnet/DashboardService.cs
+++ b/som-hackathon-starter-dotnet/DashboardService.cs
@@ -255,12 +255,22 @@ public sealed class DashboardService : BackgroundService
 
     public async Task<DecisionResult> DecideAsync(string outputId, string decision, string? reviewer, CancellationToken ct)
     {
+        // Validate the decision BEFORE removing the pending item. A malformed body
+        // (e.g. {"approved":true}) binds decision=null and, if we removed first, the
+        // staged warning would be destroyed by a downstream NRE before either branch
+        // could restore it. Reject up front so nothing is ever taken from the queue
+        // on a decision we cannot honour.
+        var verb = decision?.Trim().ToLowerInvariant();
+        if (verb is not ("approve" or "reject"))
+            return new DecisionResult(false,
+                "invalid_decision — body must be {\"decision\":\"approve\"|\"reject\"}", null);
+
         if (!_pending.TryRemove(outputId, out var pending))
             return new DecisionResult(false, "not_found", null);
 
         var key = pending.StoryKey ?? "";
 
-        if (decision.Equals("approve", StringComparison.OrdinalIgnoreCase))
+        if (verb == "approve")
         {
             // Republish to the production bus in a FRESH dashboard-attributed envelope —
             // envelope-level approved_by/at writes were schema-invalid (envelope is
@@ -302,7 +312,7 @@ public sealed class DashboardService : BackgroundService
             return new DecisionResult(true, "approved", _options.SkillEventsTopic);
         }
 
-        if (decision.Equals("reject", StringComparison.OrdinalIgnoreCase))
+        if (verb == "reject")
         {
             // Build inside the try — same restore guarantee as the approve branch.
             try
@@ -336,7 +346,7 @@ public sealed class DashboardService : BackgroundService
             return new DecisionResult(true, "rejected", _options.SkillRejectedTopic);
         }
 
-        // Unknown decision — put back the pending entry so the UI can retry.
+        // Unreachable: verb was validated to approve|reject before the item was removed.
         _pending[outputId] = pending;
         return new DecisionResult(false, "invalid_decision", null);
     }

--- a/som-hackathon-starter-dotnet/Program.cs
+++ b/som-hackathon-starter-dotnet/Program.cs
@@ -313,6 +313,10 @@ app.MapPost("/api/reset", async (DashboardService dash, CancellationToken ct) =>
 
 app.MapPost("/api/publish/{scenario}", async (string scenario, IOptions<KafkaOptions> kafka) =>
 {
+    // Reject unknown scenarios up front — RunAsync would otherwise log to stdout and
+    // return, leaving the caller a misleading 200 {"published": "<anything>"}.
+    if (!TestProducer.HasScenario(scenario))
+        return Results.NotFound(new { error = $"unknown scenario '{scenario}'", valid_scenarios = TestProducer.Scenarios });
     try
     {
         await TestProducer.RunAsync(kafka.Value, scenario);

--- a/som-hackathon-starter-dotnet/Program.cs
+++ b/som-hackathon-starter-dotnet/Program.cs
@@ -319,8 +319,12 @@ app.MapPost("/api/publish/{scenario}", async (string scenario, IOptions<KafkaOpt
         return Results.NotFound(new { error = $"unknown scenario '{scenario}'", valid_scenarios = TestProducer.Scenarios });
     try
     {
-        await TestProducer.RunAsync(kafka.Value, scenario);
-        return Results.Ok(new { published = scenario });
+        var count = await TestProducer.RunAsync(kafka.Value, scenario);
+        // A known scenario that published nothing means its seed file was missing or
+        // unparseable — surface it as a 500 instead of a misleading {"published": ...}.
+        return count > 0
+            ? Results.Ok(new { published = scenario })
+            : Results.Problem($"scenario '{scenario}' is known but nothing was published — seed file missing or unreadable");
     }
     catch (Exception ex)
     {

--- a/som-hackathon-starter-dotnet/SkillWorker.cs
+++ b/som-hackathon-starter-dotnet/SkillWorker.cs
@@ -111,7 +111,18 @@ public class SkillWorker : BackgroundService
                                 skill.Id, string.Join(",", operatesOn));
                         continue;
                     }
-                    await EvaluateSkillAsync(skill, storyContext, storyId, result.Message.Key, correlationId, previous, stoppingToken);
+                    try
+                    {
+                        await EvaluateSkillAsync(skill, storyContext, storyId, result.Message.Key, correlationId, previous, stoppingToken);
+                    }
+                    catch (Exception skillEx)
+                    {
+                        // Fail CLOSED and VISIBLE: one skill throwing must not abort the rest,
+                        // and "the check crashed" must be distinguishable on the bus from
+                        // "the check ran clean". Emit a FAILED run record, then carry on.
+                        _logger.LogError(skillEx, "Skill {SkillId} threw on {StoryId} — emitting FAILED run record", skill.Id, storyId);
+                        await PublishFailedRunAsync(skill, storyId, result.Message.Key, correlationId, stoppingToken);
+                    }
                 }
 
                 if (hasStoryId) _previousStories[storyId] = storyContext.DeepClone();
@@ -167,6 +178,26 @@ public class SkillWorker : BackgroundService
 
         _logger.LogInformation("Skill {SkillId}@{Version} on {StoryId}: {Count} warnings in {Ms}ms",
             skill.Id, skill.Version, storyId, warningIds.Count, sw.ElapsedMilliseconds);
+    }
+
+    /// <summary>
+    /// Publish a FAILED skill.run.completed record when a skill throws. Best-effort:
+    /// if even this publish fails the loop still continues (we are already in a catch),
+    /// but the local error log above preserves the evidence.
+    /// </summary>
+    private async Task PublishFailedRunAsync(SkillDefinition skill, string storyId, string? messageKey, string? correlationId, CancellationToken ct)
+    {
+        try
+        {
+            var runPayload = BuildRunRecord(skill, Guid.NewGuid().ToString(), storyId, messageKey,
+                new List<string>(), 0, failed: true);
+            var runMsg = BuildEnvelope("skill.run.completed", _options.SkillRunsTopic, correlationId, runPayload);
+            await PublishAsync(_options.SkillRunsTopic, storyId, runMsg.ToJsonString(), ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to publish FAILED run record for skill {SkillId} on {StoryId}", skill.Id, storyId);
+        }
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -233,13 +264,17 @@ public class SkillWorker : BackgroundService
     }
 
     /// <summary>Build skill.run.completed audit record (Amendment 1, hackathon brief §8.1).</summary>
+    /// <param name="failed">When true, emit outcome FAILED with human_review_required — the
+    /// skill threw and produced nothing, which must be distinguishable on the bus from a
+    /// clean run that raised no warnings (SKIPPED).</param>
     private static JsonNode BuildRunRecord(
         SkillDefinition skill,
         string runId,
         string storyId,
         string? messageKey,
         List<string> warningIds,
-        long latencyMs)
+        long latencyMs,
+        bool failed = false)
     {
         // Payload only — message_type and timestamp live on the envelope (BuildEnvelope).
         return new JsonObject
@@ -266,8 +301,8 @@ public class SkillWorker : BackgroundService
                 ["enrichment_ids"] = new JsonArray(),
             },
             ["latency_ms"] = latencyMs,
-            ["outcome"] = warningIds.Count > 0 ? "COMPLETED" : "SKIPPED",
-            ["human_review_required"] = warningIds.Count > 0,
+            ["outcome"] = failed ? "FAILED" : warningIds.Count > 0 ? "COMPLETED" : "SKIPPED",
+            ["human_review_required"] = failed || warningIds.Count > 0,
         };
     }
 

--- a/som-hackathon-starter-dotnet/SkillWorker.cs
+++ b/som-hackathon-starter-dotnet/SkillWorker.cs
@@ -111,21 +111,17 @@ public class SkillWorker : BackgroundService
                                 skill.Id, string.Join(",", operatesOn));
                         continue;
                     }
-                    try
-                    {
-                        await EvaluateSkillAsync(skill, storyContext, storyId, result.Message.Key, correlationId, previous, stoppingToken);
-                    }
-                    catch (Exception skillEx)
-                    {
-                        // Fail CLOSED and VISIBLE: one skill throwing must not abort the rest,
-                        // and "the check crashed" must be distinguishable on the bus from
-                        // "the check ran clean". Emit a FAILED run record, then carry on.
-                        _logger.LogError(skillEx, "Skill {SkillId} threw on {StoryId} — emitting FAILED run record", skill.Id, storyId);
-                        await PublishFailedRunAsync(skill, storyId, result.Message.Key, correlationId, stoppingToken);
-                    }
+                    // EvaluateSkillAsync fails CLOSED and VISIBLE on its own: a skill that
+                    // throws emits a FAILED run record and returns, so one bad skill never
+                    // aborts the rest of the loop. Shutdown cancellation still propagates.
+                    await EvaluateSkillAsync(skill, storyContext, storyId, result.Message.Key, correlationId, previous, stoppingToken);
                 }
 
                 if (hasStoryId) _previousStories[storyId] = storyContext.DeepClone();
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;   // graceful shutdown — not an error
             }
             catch (ConsumeException ex)
             {
@@ -152,49 +148,58 @@ public class SkillWorker : BackgroundService
         var sw = Stopwatch.StartNew();
         var warningIds = new List<string>();
 
-        foreach (var rule in skill.Rules)
+        try
         {
-            foreach (var match in _engine.Evaluate(rule, storyContext, previous))
+            foreach (var rule in skill.Rules)
             {
-                var warningPayload = BuildWarning(skill, match, storyId);
-                warningIds.Add(warningPayload["warning_id"]!.GetValue<string>());
-                var warningMsg = BuildEnvelope("skill.warning.raised", _options.SkillStagingTopic, correlationId, warningPayload);
-                await PublishAsync(_options.SkillStagingTopic, storyId, warningMsg.ToJsonString(), ct);
+                foreach (var match in _engine.Evaluate(rule, storyContext, previous))
+                {
+                    var warningPayload = BuildWarning(skill, match, storyId);
+                    warningIds.Add(warningPayload["warning_id"]!.GetValue<string>());
+                    var warningMsg = BuildEnvelope("skill.warning.raised", _options.SkillStagingTopic, correlationId, warningPayload);
+                    await PublishAsync(_options.SkillStagingTopic, storyId, warningMsg.ToJsonString(), ct);
+                }
             }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;   // graceful shutdown, not a skill failure — let the consume loop stop
+        }
+        catch (Exception ex)
+        {
+            // Fail CLOSED and VISIBLE: emit a FAILED run record so "the check crashed" is
+            // distinguishable on the bus from "the check ran clean", and return without
+            // rethrowing so the remaining skills for this story still run. The partial
+            // warning_ids already published to staging are carried through, not dropped.
+            sw.Stop();
+            _logger.LogError(ex, "Skill {SkillId} threw on {StoryId} after {Count} warning(s) — emitting FAILED run record",
+                skill.Id, storyId, warningIds.Count);
+            await PublishRunRecordAsync(skill, storyId, messageKey, correlationId, warningIds, sw.ElapsedMilliseconds, failed: true, ct);
+            return;
         }
 
         sw.Stop();
-
-        var runPayload = BuildRunRecord(
-            skill,
-            Guid.NewGuid().ToString(),
-            storyId,
-            messageKey,
-            warningIds,
-            sw.ElapsedMilliseconds);
-
-        var runMsg = BuildEnvelope("skill.run.completed", _options.SkillRunsTopic, correlationId, runPayload);
-        await PublishAsync(_options.SkillRunsTopic, storyId, runMsg.ToJsonString(), ct);
+        await PublishRunRecordAsync(skill, storyId, messageKey, correlationId, warningIds, sw.ElapsedMilliseconds, failed: false, ct);
 
         _logger.LogInformation("Skill {SkillId}@{Version} on {StoryId}: {Count} warnings in {Ms}ms",
             skill.Id, skill.Version, storyId, warningIds.Count, sw.ElapsedMilliseconds);
     }
 
     /// <summary>
-    /// Publish a FAILED skill.run.completed record when a skill throws. Best-effort:
-    /// if even this publish fails the loop still continues (we are already in a catch),
-    /// but the local error log above preserves the evidence.
+    /// Publish a skill.run.completed record. On the FAILED path this is best-effort — if the
+    /// publish itself throws we are already handling a skill failure, so we log and swallow
+    /// rather than let the FAILED-reporting path take down the loop.
     /// </summary>
-    private async Task PublishFailedRunAsync(SkillDefinition skill, string storyId, string? messageKey, string? correlationId, CancellationToken ct)
+    private async Task PublishRunRecordAsync(SkillDefinition skill, string storyId, string? messageKey,
+        string? correlationId, List<string> warningIds, long latencyMs, bool failed, CancellationToken ct)
     {
         try
         {
-            var runPayload = BuildRunRecord(skill, Guid.NewGuid().ToString(), storyId, messageKey,
-                new List<string>(), 0, failed: true);
+            var runPayload = BuildRunRecord(skill, Guid.NewGuid().ToString(), storyId, messageKey, warningIds, latencyMs, failed);
             var runMsg = BuildEnvelope("skill.run.completed", _options.SkillRunsTopic, correlationId, runPayload);
             await PublishAsync(_options.SkillRunsTopic, storyId, runMsg.ToJsonString(), ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (failed)
         {
             _logger.LogError(ex, "Failed to publish FAILED run record for skill {SkillId} on {StoryId}", skill.Id, storyId);
         }

--- a/som-hackathon-starter-dotnet/TestProducer.cs
+++ b/som-hackathon-starter-dotnet/TestProducer.cs
@@ -33,6 +33,9 @@ public static class TestProducer
     /// <summary>Available scenarios in the order they should appear in the UI.</summary>
     public static IReadOnlyList<string> Scenarios => ScenarioFiles.Keys.ToArray();
 
+    /// <summary>True if {scenario} names a known seed scenario (case-insensitive).</summary>
+    public static bool HasScenario(string scenario) => ScenarioFiles.ContainsKey(scenario);
+
     /// <summary>
     /// Returns the raw SOM envelope JSON for a given scenario, or null if unknown.
     /// </summary>

--- a/som-hackathon-starter-dotnet/TestProducer.cs
+++ b/som-hackathon-starter-dotnet/TestProducer.cs
@@ -70,16 +70,19 @@ public static class TestProducer
     /// CLI entry point. Builds a minimal IConfiguration since no host exists when invoked
     /// with `dotnet run -- --test-producer`.
     /// </summary>
-    public static Task RunAsync(string? scenario = null)
+    public static Task<int> RunAsync(string? scenario = null)
         => RunAsync(LoadOptionsFromConfiguration(), scenario);
 
     /// <summary>
     /// In-process entry point. Caller supplies the same KafkaOptions used by SkillWorker
     /// and DashboardService so a single config source drives every Kafka client.
     /// </summary>
-    public static async Task RunAsync(KafkaOptions options, string? scenario = null)
+    /// <summary>Publishes the requested scenario(s); returns the count actually published so
+    /// a caller can tell a valid-name-but-missing-seed miss from a real publish.</summary>
+    public static async Task<int> RunAsync(KafkaOptions options, string? scenario = null)
     {
         var topic = options.StoryContextTopic;
+        var published = 0;
 
         var config = new ProducerConfig
         {
@@ -158,8 +161,10 @@ public static class TestProducer
 
             Console.WriteLine($"  → Partition {result.Partition.Value}, Offset {result.Offset.Value}");
             Console.WriteLine();
+            published++;
         }
 
         Console.WriteLine("Done. Your skill worker should pick these up.");
+        return published;
     }
 }

--- a/som-hackathon-starter-dotnet/docs/dashboard-guide.md
+++ b/som-hackathon-starter-dotnet/docs/dashboard-guide.md
@@ -35,7 +35,7 @@ These are separate surfaces — knowing which is which is most of the learning c
 | Lane | Fed by | Card shows |
 |---|---|---|
 | **Stories on Bus** | `som.story.context` | Latest version of each story: phase, priority, warnings count, phase timeline. Click → lifecycle panel. |
-| **Skill Runs** | `som.skills.runs` | One card per skill execution: outcome (COMPLETED/SKIPPED), latency, output counts (w/s/e). Click → full run record. |
+| **Skill Runs** | `som.skills.runs` | One card per skill execution: outcome (COMPLETED / SKIPPED / FAILED — FAILED means the skill threw and needs human review), latency, output counts (w/s/e). Click → full run record. |
 | **Pending Approval** | `som.skills.staging` | Staged skill outputs awaiting your call: rule, severity, story, detail, **Approve** / **Reject**. |
 | **Decisions** | your clicks | Approvals republish to `som.skills.events`; rejections to `som.skills.rejected` — both with reviewer + timestamp stamped on the envelope. |
 

--- a/som-hackathon-starter-dotnet/wwwroot/index.html
+++ b/som-hackathon-starter-dotnet/wwwroot/index.html
@@ -639,14 +639,34 @@ const SCENARIO_LABELS = {
 
 // Tabler icon shortcut for use inside template literals.
 // ic('robot') → '<svg class="icon"><use href="#i-robot"/></svg>'
+// name is constrained to [a-z0-9-] so a bad caller can't inject markup via the href.
 function ic(name, sizeClass) {
+  const safeName = String(name).replace(/[^a-z0-9-]/g, '');
   const cls = sizeClass ? `icon ${sizeClass}` : 'icon';
-  return `<svg class="${cls}" aria-hidden="true"><use href="#i-${name}"/></svg>`;
+  return `<svg class="${cls}" aria-hidden="true"><use href="#i-${safeName}"/></svg>`;
 }
 
 function escapeHtml(s) {
   if (s === undefined || s === null) return '';
   return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+// Safe interpolation of a dynamic value as a JS-string argument inside an inline
+// HTML handler, e.g. onclick="fn(${jsArg(id)})". escapeHtml alone is WRONG here:
+// the HTML parser decodes &#39; back to ' before the JS parser runs, so a quote in
+// the value still breaks out of the string. JSON.stringify quotes+escapes for the JS
+// context; escapeHtml then guards the surrounding HTML attribute. Note: the handler
+// must use ${jsArg(x)} with NO surrounding quotes — jsArg supplies them.
+function jsArg(v) {
+  return escapeHtml(JSON.stringify(v === undefined ? null : v));
+}
+
+// Sanitize a dynamic value used as (part of) an HTML class attribute — bus/API
+// strings like lifecycle.phase or severity land in class="tag ${...}", where a "
+// would let an attacker open a new attribute (onmouseover=...). Reduce to the
+// CSS-identifier charset.
+function safeCls(v) {
+  return String(v ?? '').toLowerCase().replace(/[^a-z0-9_-]/g, '');
 }
 
 function shortId(id) {
@@ -791,7 +811,7 @@ function renderStories() {
     div.innerHTML = `
       <div class="card-top">
         <span class="card-id">${escapeHtml(id)}${seq != null ? ` <span class="seq-badge" title="sequence_number">v${escapeHtml(String(seq))}</span>` : ''}</span>
-        <span class="tag ${phase.toLowerCase()}">${escapeHtml(phase)}</span>
+        <span class="tag ${safeCls(phase)}">${escapeHtml(phase)}</span>
       </div>
       <div class="card-title">${escapeHtml(headline)}</div>
       <div class="card-meta">
@@ -848,12 +868,12 @@ function renderRuns() {
     div.innerHTML = `
       <div class="card-top">
         <span class="card-id">${escapeHtml(shortId(r.run_id))}</span>
-        <span class="tag ${(r.outcome||'').toLowerCase()}">${escapeHtml(r.outcome || '—')}</span>
+        <span class="tag ${safeCls(r.outcome)}">${escapeHtml(r.outcome || '—')}</span>
       </div>
       <div class="card-title">${escapeHtml(r.skill_id)}@${escapeHtml(r.skill_version)}</div>
       <div class="card-meta">
         <span><b>story</b> ${escapeHtml(shortId(r.story_id))}</span>
-        <span><b>${r.latency_ms} ms</b></span>
+        <span><b>${Number(r.latency_ms) || 0} ms</b></span>
         <span>w:${warnings} s:${sugg} e:${enrich}</span>
       </div>`;
     lane.appendChild(div);
@@ -915,14 +935,14 @@ function renderPending() {
       </div>
       <div class="card-title">${escapeHtml(o.rule_id || o.content_type || o.representation_type || kind)}</div>
       <div class="card-meta">
-        ${severity ? `<span class="tag ${severity}">${escapeHtml(severity.toUpperCase())}</span>` : ''}
+        ${severity ? `<span class="tag ${safeCls(severity)}">${escapeHtml(severity.toUpperCase())}</span>` : ''}
         ${o.story_id ? `<span><b>story</b> ${escapeHtml(shortId(o.story_id))}</span>` : ''}
         ${(o.affected_fields || []).length ? `<span><b>fields</b> ${escapeHtml((o.affected_fields||[]).join(','))}</span>` : ''}
       </div>
       ${o.detail ? `<div class="card-meta" style="margin-top:6px;color:var(--text-secondary);white-space:normal;line-height:1.4;">${escapeHtml(o.detail)}</div>` : ''}
       <div class="actions">
-        <button class="btn approve" onclick="event.stopPropagation();decide('${id}','approve')">${ic('check')} Approve</button>
-        <button class="btn reject" onclick="event.stopPropagation();decide('${id}','reject')">${ic('x')} Reject</button>
+        <button class="btn approve" onclick="event.stopPropagation();decide(${jsArg(id)},'approve')">${ic('check')} Approve</button>
+        <button class="btn reject" onclick="event.stopPropagation();decide(${jsArg(id)},'reject')">${ic('x')} Reject</button>
       </div>`;
     div.addEventListener('click', () => openModal(`Pending — ${id}`, raw));
     lane.appendChild(div);
@@ -1160,7 +1180,7 @@ function eventSummary(e) {
     const story = p?.payload || p;
     const phase = story?.lifecycle?.phase || '—';
     const seq = story?.sequence_number;
-    return `<b>story.context</b> · phase=${escapeHtml(phase)}${seq != null ? ` · v${seq}` : ''}`;
+    return `<b>story.context</b> · phase=${escapeHtml(phase)}${seq != null ? ` · v${escapeHtml(seq)}` : ''}`;
   }
   if (suffix === 'staging') {
     return `<b>STAGED</b> ${escapeHtml(p.rule_id || outputKind(p))} <span style="color:var(--text-muted)">[${escapeHtml(p.severity||'')}]</span> — ${escapeHtml((p.detail||'').slice(0,80))}`;
@@ -1173,7 +1193,7 @@ function eventSummary(e) {
   }
   if (suffix === 'runs') {
     const w = p?.outputs?.warning_ids?.length || 0;
-    return `<b>${escapeHtml(p.outcome || 'RAN')}</b> · skill ${escapeHtml(p.skill_id || '?')} · ${p.latency_ms}ms · ${w} warning${w===1?'':'s'}`;
+    return `<b>${escapeHtml(p.outcome || 'RAN')}</b> · skill ${escapeHtml(p.skill_id || '?')} · ${Number(p.latency_ms) || 0}ms · ${w} warning${w===1?'':'s'}`;
   }
   return `<code>${escapeHtml(topic)}</code>`;
 }
@@ -1196,7 +1216,7 @@ function renderStoryPanel() {
     const compliance = (story.compliance || []).length;
     const gates = (story.editorial_gates || []).length;
     meta.innerHTML = `
-      <span class="tag ${escapeHtml(phase.toLowerCase())}">${escapeHtml(phase)}</span>
+      <span class="tag ${safeCls(phase)}">${escapeHtml(phase)}</span>
       ${seq != null ? `<span class="tag">v${escapeHtml(String(seq))}</span>` : ''}
       ${priority ? `<span class="tag">priority ${escapeHtml(priority)}</span>` : ''}
       ${compliance ? `<span class="tag">${compliance} compliance</span>` : ''}
@@ -1210,10 +1230,10 @@ function renderStoryPanel() {
   const phase = story?.lifecycle?.phase;
   const nextPhase = phase ? PHASE_NEXT_MAP[phase] : null;
   actions.innerHTML = `
-    <button onclick="advancePhase('${escapeHtml(storyId)}')" ${nextPhase ? '' : 'disabled'} title="${nextPhase ? `${escapeHtml(phase)} → ${escapeHtml(nextPhase)}` : 'Story is at terminal phase'}">${ic('chevron-right')} ${nextPhase ? 'Advance to ' + escapeHtml(nextPhase) : 'No next phase'}</button>
-    <button onclick="addCompliance('${escapeHtml(storyId)}')">${ic('shield')} Add compliance flag</button>
-    <button onclick="rerunSkill('${escapeHtml(storyId)}')">${ic('refresh')} Re-run skill</button>
-    <button onclick="openModal('story.context — ${escapeHtml(storyId)}', stories.get('${escapeHtml(storyId)}'))" class="primary">${ic('braces')} View JSON</button>`;
+    <button onclick="advancePhase(${jsArg(storyId)})" ${nextPhase ? '' : 'disabled'} title="${nextPhase ? `${escapeHtml(phase)} → ${escapeHtml(nextPhase)}` : 'Story is at terminal phase'}">${ic('chevron-right')} ${nextPhase ? 'Advance to ' + escapeHtml(nextPhase) : 'No next phase'}</button>
+    <button onclick="addCompliance(${jsArg(storyId)})">${ic('shield')} Add compliance flag</button>
+    <button onclick="rerunSkill(${jsArg(storyId)})">${ic('refresh')} Re-run skill</button>
+    <button onclick="openModal(${jsArg('story.context — ' + storyId)}, stories.get(${jsArg(storyId)}))" class="primary">${ic('braces')} View JSON</button>`;
 
   // Timeline
   const timeline = document.getElementById('sp-timeline');
@@ -1226,11 +1246,14 @@ function renderStoryPanel() {
     timeline.innerHTML = '<div class="empty" style="padding:18px;">No events yet for this story.</div>';
     return;
   }
-  timeline.innerHTML = items.map(({e}) => {
+  // Hold the rendered events so the click handler indexes into them instead of
+  // serializing the whole payload into an HTML attribute (JSON.stringify does not
+  // escape ' or <, so any payload string could break out of the onclick).
+  _spTimelineEvents = items.map(({e}) => e);
+  timeline.innerHTML = items.map(({e}, i) => {
     const suffix = eventTopicSuffix(e.topic);
-    const u = unwrapSom(e.payload);
     return `
-      <div class="sp-event ${escapeHtml(suffix)}" onclick='openModal(${JSON.stringify(e.topic + " — " + (u.warning_id || u.run_id || u.story_id || ""))}, ${JSON.stringify(e.payload)})'>
+      <div class="sp-event ${safeCls(suffix)}" onclick="openSpEvent(${i})">
         <div class="sp-event-dot"></div>
         <div>
           <div class="sp-event-time">${escapeHtml(fmtTime(e.received_at))} · <code>${escapeHtml(e.topic)}</code></div>
@@ -1238,6 +1261,15 @@ function renderStoryPanel() {
         </div>
       </div>`;
   }).join('');
+}
+
+// Open the modal for a story-panel timeline event by index into the last render.
+let _spTimelineEvents = [];
+function openSpEvent(i) {
+  const e = _spTimelineEvents[i];
+  if (!e) return;
+  const u = unwrapSom(e.payload);
+  openModal(e.topic + ' — ' + (u.warning_id || u.run_id || u.story_id || ''), e.payload);
 }
 
 // ── Lifecycle simulator actions ──
@@ -1801,7 +1833,7 @@ async function renderSimulator() {
           : `<button class="btn approve sm" onclick="startAutoStream()">${ic('player-play','icon-sm')} Start</button>`}
       </div>
       <div class="card-meta" style="margin-top:6px;color:var(--text-secondary);line-height:1.4;">
-        Publish a random seed scenario every <input type="number" id="auto-interval" value="${status.autoIntervalSeconds}" min="3" max="600" style="width:60px;padding:2px 4px;background:var(--bg-input);border:1px solid var(--border);border-radius:4px;color:var(--text);"> seconds.
+        Publish a random seed scenario every <input type="number" id="auto-interval" value="${Number(status.autoIntervalSeconds) || 30}" min="3" max="600" style="width:60px;padding:2px 4px;background:var(--bg-input);border:1px solid var(--border);border-radius:4px;color:var(--text);"> seconds.
         Useful for keeping the dashboard alive during demos and giving vendor skills a steady test load.
       </div>
     </div>`;
@@ -1810,14 +1842,14 @@ async function renderSimulator() {
     <div class="card" style="cursor:default;border-left:3px solid var(--accent2);">
       <div class="card-top">
         <span class="card-id" style="color:var(--ice);">${escapeHtml(s.id)}</span>
-        <span class="tag">${s.duration_seconds}s · ${s.step_count} steps</span>
+        <span class="tag">${Number(s.duration_seconds) || 0}s · ${Number(s.step_count) || 0} steps</span>
       </div>
       <div class="card-title">${escapeHtml(s.name)}</div>
       <div class="card-meta" style="white-space:normal;color:var(--text-secondary);line-height:1.5;margin-top:6px;">
         ${escapeHtml(s.description)}
       </div>
       <div class="actions" style="margin-top:10px;">
-        <button class="btn approve" onclick="runSimulatorScenario('${escapeHtml(s.id)}')" ${running ? 'disabled' : ''}>${ic('player-play','icon-sm')} Run scenario</button>
+        <button class="btn approve" onclick="runSimulatorScenario(${jsArg(s.id)})" ${running ? 'disabled' : ''}>${ic('player-play','icon-sm')} Run scenario</button>
       </div>
     </div>`).join('');
 
@@ -1829,15 +1861,15 @@ async function renderSimulator() {
     <div class="card" style="cursor:default;border-left:3px solid var(--ice);">
       <div class="card-top">
         <span class="card-id" style="color:var(--ice);">${escapeHtml(m.sourceId)}</span>
-        <span class="tag">${m.durationSeconds}s · asset ${escapeHtml(m.assetId)}</span>
+        <span class="tag">${Number(m.durationSeconds) || 0}s · asset ${escapeHtml(m.assetId)}</span>
       </div>
       <div class="card-title">${escapeHtml(m.label)}</div>
       <div class="card-meta" style="white-space:normal;color:var(--text-secondary);line-height:1.5;margin-top:6px;">
         ${escapeHtml(m.notes || '')}
       </div>
       <div class="actions" style="margin-top:10px;">
-        <button class="btn approve" onclick="emitMam('${escapeHtml(m.sourceId)}')">${ic('player-play','icon-sm')} Emit media_available</button>
-        <button class="btn" onclick="emitMam('${escapeHtml(m.sourceId)}', true)" title="Adds extensions['com.ibc-poc.capture_complete'] — the media coordinator flips the asset to CAPTURED and skills re-run">${ic('check','icon-sm')} Emit final (capture complete)</button>
+        <button class="btn approve" onclick="emitMam(${jsArg(m.sourceId)})">${ic('player-play','icon-sm')} Emit media_available</button>
+        <button class="btn" onclick="emitMam(${jsArg(m.sourceId)}, true)" title="Adds extensions['com.ibc-poc.capture_complete'] — the media coordinator flips the asset to CAPTURED and skills re-run">${ic('check','icon-sm')} Emit final (capture complete)</button>
       </div>
     </div>`).join('');
 
@@ -2039,7 +2071,7 @@ async function renderSkillList(selectedId) {
     : skills[0];
 
   const tabs = skills.map(s => `
-    <button class="skill-tab ${s.id === current.id ? 'active' : ''}" onclick="renderSkillList('${escapeHtml(s.id)}')">
+    <button class="skill-tab ${s.id === current.id ? 'active' : ''}" onclick="renderSkillList(${jsArg(s.id)})">
       <strong>${escapeHtml(s.name || s.id)}</strong>
       <small>${escapeHtml(s.id)} · ${(s.rules||[]).length} rule${(s.rules||[]).length===1?'':'s'}</small>
     </button>`).join('');
@@ -2064,7 +2096,7 @@ function renderSkillDetail(skill) {
     <div class="card" style="cursor:default;border-left:3px solid var(--accent);">
       <div class="card-top">
         <span class="card-id" style="font-size:11px;color:var(--ice);">${escapeHtml(rule.rule_id)}</span>
-        <span class="tag ${escapeHtml((rule.default_severity||'').toLowerCase())}">${escapeHtml((rule.default_severity||'').toUpperCase())}</span>
+        <span class="tag ${safeCls(rule.default_severity)}">${escapeHtml((rule.default_severity||'').toUpperCase())}</span>
       </div>
       <div class="card-title">${escapeHtml(rule.name || rule.rule_id)}</div>
       <div class="card-meta" style="white-space:normal;color:var(--text-secondary);line-height:1.5;margin-top:6px;">
@@ -2080,8 +2112,8 @@ function renderSkillDetail(skill) {
         <div class="code-block" style="padding:8px 10px;font-size:11px;">${escapeHtml(JSON.stringify(rule.config, null, 2))}</div>
       </div>
       <div class="actions" style="margin-top:10px;">
-        <button class="btn" onclick="openRuleEditor('${escapeHtml(skill.id)}', ${idx})">${ic('pencil','icon-sm')} Edit rule</button>
-        <button class="btn reject" onclick="deleteRule('${escapeHtml(skill.id)}', ${idx})">${ic('trash','icon-sm')} Delete</button>
+        <button class="btn" onclick="openRuleEditor(${jsArg(skill.id)}, ${idx})">${ic('pencil','icon-sm')} Edit rule</button>
+        <button class="btn reject" onclick="deleteRule(${jsArg(skill.id)}, ${idx})">${ic('trash','icon-sm')} Delete</button>
       </div>
     </div>`).join('');
 
@@ -2099,10 +2131,10 @@ function renderSkillDetail(skill) {
           <span class="card-id" style="font-size:12px;color:var(--ice);">${escapeHtml(skill.id)} @ ${escapeHtml(skill.version)}</span>
           <div style="display:flex;gap:6px;">
             <span class="tag suggestion">${escapeHtml((skill.skill_type||'').toUpperCase())}</span>
-            <button class="btn sm" onclick="dryRunSkill('${escapeHtml(skill.id)}')" title="Evaluate this skill against all 6 seed stories">${ic('flask','icon-sm')} Dry-run</button>
-            <button class="btn sm" onclick="aiReviewSkill('${escapeHtml(skill.id)}')" title="AI-powered editorial review">${ic('robot','icon-sm')} AI review</button>
-            <button class="btn sm" onclick="openSkillEditor('${escapeHtml(skill.id)}')">${ic('pencil','icon-sm')} Edit</button>
-            <button class="btn sm reject" onclick="deleteSkill('${escapeHtml(skill.id)}')">${ic('trash','icon-sm')}</button>
+            <button class="btn sm" onclick="dryRunSkill(${jsArg(skill.id)})" title="Evaluate this skill against all 6 seed stories">${ic('flask','icon-sm')} Dry-run</button>
+            <button class="btn sm" onclick="aiReviewSkill(${jsArg(skill.id)})" title="AI-powered editorial review">${ic('robot','icon-sm')} AI review</button>
+            <button class="btn sm" onclick="openSkillEditor(${jsArg(skill.id)})">${ic('pencil','icon-sm')} Edit</button>
+            <button class="btn sm reject" onclick="deleteSkill(${jsArg(skill.id)})">${ic('trash','icon-sm')}</button>
           </div>
         </div>
         <div class="card-title" style="font-size:15px;">${escapeHtml(skill.name)}</div>
@@ -2132,7 +2164,7 @@ function renderSkillDetail(skill) {
       <div>
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;">
           <div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.05em;">Rules (${(skill.rules||[]).length})</div>
-          <button class="btn sm" onclick="openRuleEditor('${escapeHtml(skill.id)}')">${ic('plus','icon-sm')} Add rule</button>
+          <button class="btn sm" onclick="openRuleEditor(${jsArg(skill.id)})">${ic('plus','icon-sm')} Add rule</button>
         </div>
         <div style="display:grid;gap:8px;">${rulesHtml || '<div class="empty" style="padding:20px;">No rules yet — click "Add rule" above.</div>'}</div>
       </div>
@@ -2157,7 +2189,7 @@ async function openSkillEditor(skillId) {
   const body = document.getElementById('modal-body');
   document.getElementById('modal-title').textContent = isEdit ? `Edit skill — ${initial.id}` : 'Add skill';
   body.innerHTML = `
-    <form id="skill-form" onsubmit="event.preventDefault();saveSkill(${isEdit ? `'${escapeHtml(skillId)}'` : 'null'});">
+    <form id="skill-form" onsubmit="event.preventDefault();saveSkill(${isEdit ? `${jsArg(skillId)}` : 'null'});">
       <div class="form-grid">
         <label>Skill id <small>(e.g. "vendor/skill-name")</small>
           <input name="id" value="${escapeHtml(initial.id)}" ${isEdit ? '' : 'required'} placeholder="acme/style-validator"/></label>
@@ -2187,7 +2219,7 @@ async function openSkillEditor(skillId) {
       <label>Produces <small>(comma-separated message_types)</small>
         <input name="produces" value="${escapeHtml((initial.produces || []).join(', '))}"/></label>
       <div class="form-actions">
-        <button type="button" class="btn" onclick="renderSkillList('${escapeHtml(initial.id)}')">Cancel</button>
+        <button type="button" class="btn" onclick="renderSkillList(${jsArg(initial.id)})">Cancel</button>
         <button type="submit" class="btn approve">${isEdit ? 'Save changes' : 'Create skill'}</button>
       </div>
     </form>
@@ -2247,7 +2279,7 @@ function renderDryRunResult(result, skillId) {
       ? `<div style="color:var(--text-muted);font-size:11px;">${escapeHtml(s.note || 'no matches')}</div>`
       : s.matches.map(m => `
           <div style="border-top:1px solid var(--border);padding-top:6px;margin-top:6px;">
-            <div><span class="tag ${escapeHtml(m.severity)}">${escapeHtml(m.severity.toUpperCase())}</span> <code style="font-size:10px;color:var(--ice);">${escapeHtml(m.ruleId)}</code></div>
+            <div><span class="tag ${safeCls(m.severity)}">${escapeHtml(m.severity.toUpperCase())}</span> <code style="font-size:10px;color:var(--ice);">${escapeHtml(m.ruleId)}</code></div>
             <div style="font-size:11px;color:var(--text-secondary);margin-top:4px;line-height:1.4;">${escapeHtml(m.detail)}</div>
           </div>`).join('');
     return `
@@ -2266,8 +2298,8 @@ function renderDryRunResult(result, skillId) {
     </div>
     <div style="display:grid;gap:8px;">${cards}</div>
     <div class="form-actions">
-      <button class="btn" onclick="renderSkillList('${escapeHtml(skillId)}')">← Back to skill</button>
-      <button class="btn primary-btn" onclick="aiReviewSkill('${escapeHtml(skillId)}')">${ic('robot','icon-sm')} Run AI review</button>
+      <button class="btn" onclick="renderSkillList(${jsArg(skillId)})">← Back to skill</button>
+      <button class="btn primary-btn" onclick="aiReviewSkill(${jsArg(skillId)})">${ic('robot','icon-sm')} Run AI review</button>
     </div>`;
 }
 
@@ -2300,7 +2332,7 @@ function renderAiReviewResult(result, skillId) {
         </div>
       </div>
       <div class="form-actions">
-        <button class="btn" onclick="renderSkillList('${escapeHtml(skillId)}')">← Back</button>
+        <button class="btn" onclick="renderSkillList(${jsArg(skillId)})">← Back</button>
       </div>`;
   }
 
@@ -2312,7 +2344,7 @@ function renderAiReviewResult(result, skillId) {
         <div style="margin-top:8px;font-size:12px;color:var(--text-secondary);">${escapeHtml(result.error)}</div>
       </div>
       <div class="form-actions">
-        <button class="btn" onclick="renderSkillList('${escapeHtml(skillId)}')">← Back</button>
+        <button class="btn" onclick="renderSkillList(${jsArg(skillId)})">← Back</button>
       </div>`;
   }
 
@@ -2336,8 +2368,8 @@ function renderAiReviewResult(result, skillId) {
     <div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.05em;margin:14px 0 6px;">Findings (${(result.findings||[]).length})</div>
     <div style="display:grid;gap:8px;">${findings || '<div class="empty" style="padding:18px;">No findings returned.</div>'}</div>
     <div class="form-actions">
-      <button class="btn" onclick="renderSkillList('${escapeHtml(skillId)}')">← Back to skill</button>
-      <button class="btn" onclick="dryRunSkill('${escapeHtml(skillId)}')">${ic('flask','icon-sm')} Dry-run again</button>
+      <button class="btn" onclick="renderSkillList(${jsArg(skillId)})">← Back to skill</button>
+      <button class="btn" onclick="dryRunSkill(${jsArg(skillId)})">${ic('flask','icon-sm')} Dry-run again</button>
     </div>`;
 }
 
@@ -2434,7 +2466,7 @@ async function openRuleEditor(skillId, ruleIdx) {
     : `Add rule to ${skill.id}`;
 
   body.innerHTML = `
-    <form id="rule-form" onsubmit="event.preventDefault();saveRule('${escapeHtml(skillId)}', ${ruleIdx ?? 'null'});">
+    <form id="rule-form" onsubmit="event.preventDefault();saveRule(${jsArg(skillId)}, ${ruleIdx ?? 'null'});">
       <div class="form-grid">
         <label>Rule id <input name="rule_id" value="${escapeHtml(r.rule_id)}" required placeholder="my-skill-style-001"/></label>
         <label>Default severity
@@ -2462,7 +2494,7 @@ async function openRuleEditor(skillId, ruleIdx) {
       <label>Detail template <small>(supports placeholders like {term}, {field}, {value}, {phase})</small>
         <input name="detail_template" value="${escapeHtml(r.detail_template || '')}"/></label>
       <div class="form-actions">
-        <button type="button" class="btn" onclick="renderSkillList('${escapeHtml(skillId)}')">Cancel</button>
+        <button type="button" class="btn" onclick="renderSkillList(${jsArg(skillId)})">Cancel</button>
         <button type="submit" class="btn approve">${isEdit ? 'Save rule' : 'Add rule'}</button>
       </div>
     </form>`;

--- a/som-hackathon-starter-dotnet/wwwroot/index.html
+++ b/som-hackathon-starter-dotnet/wwwroot/index.html
@@ -141,6 +141,7 @@ button { font: inherit; cursor: pointer; }
 .tag.hold { background: #3a1818; color: #fca5a5; }
 .tag.completed { background: #12302a; color: #6ee7b7; }
 .tag.skipped { background: #1a2236; color: var(--text-muted); }
+.tag.failed { background: #3a1818; color: #fca5a5; }
 .tag.approved { background: #12302a; color: #6ee7b7; }
 .tag.rejected { background: #3a1818; color: #fca5a5; }
 .tag.warning { background: #28291a; color: #e8d580; }
@@ -158,6 +159,7 @@ button { font: inherit; cursor: pointer; }
 [data-theme="light"] .tag.hold { background: #fee2e2; color: #991b1b; }
 [data-theme="light"] .tag.completed { background: #d1fae5; color: #065f46; }
 [data-theme="light"] .tag.skipped { background: #e5e7eb; color: #374151; }
+[data-theme="light"] .tag.failed { background: #fee2e2; color: #991b1b; }
 [data-theme="light"] .tag.approved { background: #d1fae5; color: #065f46; }
 [data-theme="light"] .tag.rejected { background: #fee2e2; color: #991b1b; }
 [data-theme="light"] .tag.warning { background: #fef3c7; color: #92400e; }
@@ -1198,6 +1200,10 @@ function eventSummary(e) {
   return `<code>${escapeHtml(topic)}</code>`;
 }
 
+// Backing buffer for the story-panel timeline: openSpEvent indexes into this instead
+// of the payload being serialized into an onclick attribute. Declared before its
+// writer (renderStoryPanel) and reader (openSpEvent).
+let _spTimelineEvents = [];
 function renderStoryPanel() {
   if (!_openStoryId) return;
   const storyId = _openStoryId;
@@ -1264,7 +1270,6 @@ function renderStoryPanel() {
 }
 
 // Open the modal for a story-panel timeline event by index into the last render.
-let _spTimelineEvents = [];
 function openSpEvent(i) {
   const e = _spTimelineEvents[i];
   if (!e) return;
@@ -1323,8 +1328,8 @@ async function rerunSkill(storyId) {
 async function publish(scenario) {
   try {
     const res = await fetch(`/api/publish/${encodeURIComponent(scenario)}`, { method: 'POST' });
-    if (!res.ok) console.error('publish failed', await res.text());
-  } catch (err) { console.error(err); }
+    if (!res.ok) { const t = await res.text(); console.error('publish failed', t); showToast(`Publish failed: ${t}`, 'danger'); }
+  } catch (err) { console.error(err); showToast('Publish failed: ' + err.message, 'danger'); }
 }
 
 async function decide(id, decision) {
@@ -1334,8 +1339,8 @@ async function decide(id, decision) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ decision, reviewer: 'dashboard-user' }),
     });
-    if (!res.ok) console.error('decision failed', await res.text());
-  } catch (err) { console.error(err); }
+    if (!res.ok) { const t = await res.text(); console.error('decision failed', t); showToast(`Decision failed: ${t}`, 'danger'); }
+  } catch (err) { console.error(err); showToast('Decision failed: ' + err.message, 'danger'); }
 }
 
 function clearTimeline() {
@@ -1675,7 +1680,7 @@ function openHelp(tab) {
 async function renderHelp() {
   const body = document.getElementById('modal-body');
   const tabBtn = (id, label) => `
-    <button onclick="openHelp('${id}')" style="padding:6px 14px;font-size:12px;font-weight:600;cursor:pointer;border-radius:6px 6px 0 0;border:1px solid ${helpTab === id ? 'var(--border)' : 'transparent'};border-bottom:none;background:${helpTab === id ? 'var(--bg-surface2)' : 'transparent'};color:${helpTab === id ? 'var(--text)' : 'var(--text-muted)'};">${label}</button>`;
+    <button onclick="openHelp(${jsArg(id)})" style="padding:6px 14px;font-size:12px;font-weight:600;cursor:pointer;border-radius:6px 6px 0 0;border:1px solid ${helpTab === id ? 'var(--border)' : 'transparent'};border-bottom:none;background:${helpTab === id ? 'var(--bg-surface2)' : 'transparent'};color:${helpTab === id ? 'var(--text)' : 'var(--text-muted)'};">${label}</button>`;
   const bar = `<div style="display:flex;gap:2px;border-bottom:1px solid var(--border);margin-bottom:12px;">${tabBtn('quick', 'Quick reference')}${tabBtn('guide', 'User guide')}</div>`;
 
   if (helpTab === 'guide') {
@@ -1874,7 +1879,7 @@ async function renderSimulator() {
     </div>`).join('');
 
   const tabBtn = (id, label, live) => `
-    <button onclick="setSimTab('${id}')" style="padding:6px 14px;font-size:12px;font-weight:600;cursor:pointer;border-radius:6px 6px 0 0;border:1px solid ${simTab === id ? 'var(--border)' : 'transparent'};border-bottom:none;background:${simTab === id ? 'var(--bg-surface2)' : 'transparent'};color:${simTab === id ? 'var(--text)' : 'var(--text-muted)'};">
+    <button onclick="setSimTab(${jsArg(id)})" style="padding:6px 14px;font-size:12px;font-weight:600;cursor:pointer;border-radius:6px 6px 0 0;border:1px solid ${simTab === id ? 'var(--border)' : 'transparent'};border-bottom:none;background:${simTab === id ? 'var(--bg-surface2)' : 'transparent'};color:${simTab === id ? 'var(--text)' : 'var(--text-muted)'};">
       ${label}${live ? ' <span style="color:#6ee7b7;">●</span>' : ''}
     </button>`;
 
@@ -2014,6 +2019,7 @@ function computeStatsForSkill(skillId) {
   const total = filteredRuns.length;
   const completed = filteredRuns.filter(r => r.outcome === 'COMPLETED').length;
   const skipped = filteredRuns.filter(r => r.outcome === 'SKIPPED').length;
+  const failed = filteredRuns.filter(r => r.outcome === 'FAILED').length;
   const avgLatency = total === 0 ? 0
     : Math.round(filteredRuns.reduce((s, r) => s + (r.latency_ms || 0), 0) / total);
   const totalWarnings = filteredRuns.reduce((s, r) => s + (r.outputs?.warning_ids?.length || 0), 0);
@@ -2027,7 +2033,7 @@ function computeStatsForSkill(skillId) {
     : pending.size;
   const decided = approved + rejected;
   const approvalRate = decided === 0 ? null : Math.round((approved / decided) * 100);
-  return { total, completed, skipped, avgLatency, totalWarnings,
+  return { total, completed, skipped, failed, avgLatency, totalWarnings,
            approved, rejected, pendingNow, approvalRate };
 }
 
@@ -2152,7 +2158,7 @@ function renderSkillDetail(skill) {
       <div>
         <div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:6px;">Live runtime stats — ${escapeHtml(skill.id)} (this session)</div>
         <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px;">
-          ${statBox('Runs', stats.total, `${stats.completed} done · ${stats.skipped} skipped`)}
+          ${statBox('Runs', stats.total, `${stats.completed} done · ${stats.skipped} skipped${stats.failed ? ` · ${stats.failed} failed` : ''}`)}
           ${statBox('Avg latency', stats.avgLatency + ' ms', '')}
           ${statBox('Warnings', stats.totalWarnings, '')}
           ${statBox('Pending', stats.pendingNow, 'awaiting decision')}


### PR DESCRIPTION
Stacked on **#330** (base `som-v032-readiness`). Fixes three dashboard defects and hardens the DOM-XSS surface in the single-file SPA. No schema or wire changes.

## Bug fixes

1. **Malformed decision destroyed staged warnings.** `DecideAsync` removed the pending item before validating the verb, so `{"approved":true}` (Decision binds null) hit an NRE after `TryRemove`, outside the restore-try — the staged warning was gone with nothing published. Now the verb is validated (null-safe, trimmed) **before** anything leaves the queue; invalid → 400, item stays pending and approvable.
2. **`/api/publish/{scenario}` lied.** Returned 200 `{"published":"<anything>"}` for unknown names (and, one layer down, for a *known* name whose seed file was missing). Now: unknown → 404 with the valid list; `RunAsync` reports how many it actually published so a known-but-missing seed → 500 instead of a false 200.
3. **A skill crash failed open and silently.** One skill throwing was caught at the story level, aborting the remaining skills and publishing nothing — "checked clean" and "check crashed" were indistinguishable on the bus. Each skill now runs in its own try/catch and emits a `skill.run.completed` record with `outcome: FAILED` + `human_review_required` (carrying any partial warnings it published first), then the loop continues. Shutdown cancellation propagates cleanly instead of masquerading as mass failure. The dashboard renders FAILED in red and counts it.

*(The `migration_policy` routing item from the same 8-Aug list is intentionally excluded — it's a working-group question about intended gating, not a defect.)*

## DOM-XSS cleanup

The real vulnerability class was inline handlers built by string concatenation — `onclick="fn('${escapeHtml(id)}')"` — where `escapeHtml` is the **wrong** escaper: the HTML parser decodes `&#39;` back to `'` before the JS parser runs, so a quote in a bus/API value still breaks out of the JS string. (Snyk's DOMXSS rule does not flag these handler breakouts — it flags `innerHTML` sinks, which were mostly already escaped — so this is verified by exploit-test, not scanner delta.)

- New `jsArg(v)` = `escapeHtml(JSON.stringify(v))` (JSON escaping guards the JS context, entity escaping the attribute); swept ~30 handler args including the fully-unescaped `decide('${id}')` buttons.
- New `safeCls(v)` for the `class="tag ${bus.severity}"` injections.
- The story-panel timeline serialized the **entire bus payload** into an onclick via `JSON.stringify` (which escapes neither `'` nor `<`) — replaced with an index into a buffered array (`openSpEvent`).
- Numeric fields coerced; `ic(name)` constrained.
- Left intact and documented as safe: `showToast` (textContent), `mdToHtml` (escape-first), the static SVG/help producers, and the render helpers that escape every field internally.

## Verified

- `dotnet build` 0/0; `schema/validate.py` green; Snyk 0 on the changed C#.
- **Exploit test (live):** injected a staging warning whose `warning_id` carried a JS breakout, `severity` an attribute breakout, and `detail` an `<img onerror>` — all three inert (no probe fired) while approve still passed the exact raw id to the API. Full click-through intact.
- **Bug fixes (live):** malformed decision → 400 + item survived + approved after; unknown scenario → 404; fault-injected skill → FAILED record on `som.skills.runs` while siblings still ran; FAILED renders red and increments the stat.

## Known residual

Snyk still reports 8 `DOMXSS` findings on `innerHTML` sinks that are escaped or trusted-HTML producers (guide / topology / render-producers / textContent toast) — heuristic sink-pattern flags, each proven inert above. Clearing the gate would need a `.snyk` policy or a DOM-building rewrite of a working file; deferred as a separate decision rather than suppressed here.